### PR TITLE
Support Mastodon 2.8.4

### DIFF
--- a/src/client/__tests__/gateway.spec.ts
+++ b/src/client/__tests__/gateway.spec.ts
@@ -17,6 +17,7 @@ describe('Gateway', () => {
   beforeEach(() => {
     gateway = new Gateway({
       uri: 'https://example.com',
+      version: '99.9.9',
       streamingApiUrl: 'wss://example.com',
     });
 
@@ -37,12 +38,12 @@ describe('Gateway', () => {
   test('version has been set if construct with version ', () => {
     gateway = new Gateway({
       uri: 'https://example.com',
-      version: '99.9.9',
+      version: '1.2.3',
     });
-    expect(gateway.version).toBe('99.9.9');
+    expect(gateway.version).toBe('1.2.3');
   });
 
-  test('version has been set if construct with accessToken', () => {
+  test('accessToken has been set if construct with accessToken', () => {
     gateway = new Gateway({
       uri: 'https://example.com',
       accessToken: 'token token',
@@ -300,15 +301,23 @@ describe('Gateway', () => {
   test('initialize MastoEvents and call connect with given params', async () => {
     const params = { a: 'a', b: 'b' };
     await gateway.stream('/', params);
-    expect(connectMock).toBeCalledWith('wss://example.com/?a=a&b=b');
+    expect(connectMock).toBeCalledWith('wss://example.com/?a=a&b=b', []);
   });
 
   test('initialize MastoEvents and call connect with access token', async () => {
     gateway.accessToken = 'tokentoken';
     await gateway.stream('/');
+    expect(connectMock).toBeCalledWith('wss://example.com/', ['tokentoken']);
+  });
+
+  test('initialize MastoEvents and call connect with access token as a param for Mastodon < v2.8.4', async () => {
+    gateway.version = '2.8.3';
+    gateway.accessToken = 'tokentoken';
+    await gateway.stream('/');
 
     expect(connectMock).toBeCalledWith(
       'wss://example.com/?access_token=tokentoken',
+      [],
     );
   });
 

--- a/src/client/__tests__/masto-events.spec.ts
+++ b/src/client/__tests__/masto-events.spec.ts
@@ -36,9 +36,12 @@ describe('MastoEvents', () => {
       }
     });
 
-    await mastoEvents.connect('wss://example.com');
+    await mastoEvents.connect('wss://example.com', []);
 
-    expect((WebSocket as any) as jest.Mock).toBeCalledWith('wss://example.com');
+    expect((WebSocket as any) as jest.Mock).toBeCalledWith(
+      'wss://example.com',
+      [],
+    );
 
     expect(addEventListenerMock).toHaveBeenCalledWith(
       'message',

--- a/src/client/gateway.ts
+++ b/src/client/gateway.ts
@@ -43,7 +43,7 @@ export class Gateway {
   /** Version of the current instance */
   public version = '';
   /** API token of the user */
-  public accessToken = '';
+  public accessToken?: string;
 
   /**
    * @param params Parameters
@@ -321,9 +321,9 @@ export class Gateway {
     // Since v2.8.4, Using `Sec-Websocket-Protocl` to
     // Pass token string is supported
     // https://github.com/tootsuite/mastodon/pull/10818
-    if (version && semver.gte(version, '2.8.4')) {
+    if (this.accessToken && version && semver.gte(version, '2.8.4')) {
       protocols.push(this.accessToken);
-    } else {
+    } else if (this.accessToken) {
       params.access_token = this.accessToken;
     }
 

--- a/src/client/masto-events.ts
+++ b/src/client/masto-events.ts
@@ -36,11 +36,12 @@ export class MastoEvents extends EventEmitter {
   /**
    * Connect to the websocket endpoint
    * @param url URL of the websocket endpoint
+   * @param protocols Subprotocol(s) for `Sec-Websocket-Protocol`
    * @param params URL parameters
    */
-  public connect(url: string) {
+  public connect(url: string, protocols?: string | string[]) {
     return new Promise<MastoEvents>((resolve, reject) => {
-      this.ws = new WebSocket(url);
+      this.ws = new WebSocket(url, protocols);
 
       this.ws.addEventListener('message', this.handleMessage);
       this.ws.addEventListener('error', reject);


### PR DESCRIPTION
- Use `Sec-Websocket-Protocol` to pass token instead of querystring (tootsuite/mastodon#10818)