### PR TITLE
fix return type of createStatus

### DIFF
--- a/src/client/masto.ts
+++ b/src/client/masto.ts
@@ -1097,12 +1097,12 @@ export class Masto {
   @available({ since: '0.0.0' })
   public createStatus(params?: CreateStatusParams, idempotencyKey?: string) {
     if (idempotencyKey) {
-      return this.gateway.post('/api/v1/statuses', params, {
+      return this.gateway.post<Status>('/api/v1/statuses', params, {
         headers: { 'Idempotency-Key': idempotencyKey },
       });
     }
 
-    return this.gateway.post('/api/v1/statuses', params);
+    return this.gateway.post<Status>('/api/v1/statuses', params);
   }
 
   /**


### PR DESCRIPTION
Hi there! `createStatus` was returning a `Promise<{}>` when called, which made it difficult to use the result. This PR fixes that issue.

`masto.d.ts` before this PR:
```ts
createStatus(params?: CreateStatusParams, idempotencyKey?: string): Promise<{}>;
```

`masto.d.ts` after this PR:
```ts
createStatus(params?: CreateStatusParams, idempotencyKey?: string): Promise<Status>;
```