### PR TITLE
Fix typo of `FetchAccessTokenParamsWithPassword`

### DIFF
--- a/src/client/params.ts
+++ b/src/client/params.ts
@@ -103,7 +103,7 @@ export interface FetchAccessTokenParamsWithAuthorizationCode
   client_secret: string;
 }
 
-export interface FetchAccessTokenParamsWithPassowrd
+export interface FetchAccessTokenParamsWithPassword
   extends FetchAccessTokenParamsBase<'password'> {
   /** Password */
   password: string;


### PR DESCRIPTION
Closes #54 