### PR TITLE
Add supports of Mastodon 2.9.1 RC1

### DIFF
--- a/src/client/masto.ts
+++ b/src/client/masto.ts
@@ -1130,7 +1130,7 @@ export class Masto {
    */
   @available({ since: '0.0.0' })
   public removeStatus(id: string) {
-    return this.gateway.delete<void>(`/api/v1/statuses/${id}`);
+    return this.gateway.delete<Status>(`/api/v1/statuses/${id}`);
   }
 
   /**

--- a/src/client/params.ts
+++ b/src/client/params.ts
@@ -160,6 +160,8 @@ export interface ModifyListAccountsParams {
 }
 
 export interface FetchNotificationsParams extends PaginationParams {
+  /** ID of the account */
+  account_id?: string | null;
   /** Array of notifications to exclude (Allowed values: "follow", "favourite", "reblog", "mention") */
   exclude_types?: NotificationType[] | null;
 }


### PR DESCRIPTION
- Add `account_id` param to `fetchNotification` tootsuite/mastodon#10796
- Change return type of `removeStatus` to `Status` tootsuite/mastodon#10669