### PR TITLE
Support Mastodon 3.1.4

### DIFF
--- a/src/clients/masto/__tests__/__snapshots__/masto.spec.ts.snap
+++ b/src/clients/masto/__tests__/__snapshots__/masto.spec.ts.snap
@@ -1932,6 +1932,25 @@ exports[`Masto streamPublicTimeline 1`] = `
 }
 `;
 
+exports[`Masto streamRemotePublicTimeline 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "/api/v1/streaming",
+      Object {
+        "stream": "public:remote",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
 exports[`Masto streamTagTimeline 1`] = `
 [MockFunction] {
   "calls": Array [

--- a/src/clients/masto/__tests__/masto.spec.ts
+++ b/src/clients/masto/__tests__/masto.spec.ts
@@ -36,6 +36,12 @@ describe('Masto', () => {
     expect(mockStream).toMatchSnapshot();
   });
 
+  test('streamRemotePublicTimeline', async () => {
+    await masto.streamRemotePublicTimeline();
+    expect(mockStream).toBeCalledTimes(1);
+    expect(mockStream).toMatchSnapshot();
+  });
+
   test('streamCommunityTimeline', async () => {
     await masto.streamCommunityTimeline();
     expect(mockStream).toBeCalledTimes(1);

--- a/src/clients/masto/masto.ts
+++ b/src/clients/masto/masto.ts
@@ -102,6 +102,18 @@ export class Masto extends GatewayImpl {
   }
 
   /**
+   * Stream remote public timeline
+   * @return Instance of EventEmitter
+   * @see https://docs.joinmastodon.org/methods/timelines/streaming/
+   */
+  @available({ since: '0.0.0' })
+  streamRemotePublicTimeline() {
+    return this.stream('/api/v1/streaming', {
+      stream: 'public:remote',
+    });
+  }
+
+  /**
    * Starting tag timeline streaming
    * @param id ID of the tag
    * @return Instance of EventEmitter

--- a/src/clients/masto/params.ts
+++ b/src/clients/masto/params.ts
@@ -284,6 +284,8 @@ export interface FetchTimelineParams extends PaginationParams {
   local?: boolean | null;
   /** Show only statuses with media attached? Defaults to false. */
   onlyMedia?: boolean | null;
+  /** Remote only */
+  remote?: boolean | null;
 }
 
 export interface FetchAccountStatusesParams extends PaginationParams {

--- a/src/entities/instance.ts
+++ b/src/entities/instance.ts
@@ -27,6 +27,8 @@ export interface Instance {
   urls: InstanceURLs;
   /** Statistics about how much information the instance contains. */
   stats: InstanceStats;
+  /** Whether invitation in enabled */
+  invitesEnabled: boolean;
 
   /** Banner image for the website. */
   thumbnail?: string | null;


### PR DESCRIPTION
Resolves #250 

- [x] `remote` param tootsuite/mastodon#13504
- [x] `invites_enabled` tootsuite/mastodon#13501