### PR TITLE
Add Masto#fetchMediaAttachment and Masto#waitForMediaAttachment

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,6 +21,7 @@
     "jest": true
   },
   "rules": {
+    "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/explicit-member-accessibility": [
       "error",

--- a/examples/create-new-status-with-image.ts
+++ b/examples/create-new-status-with-image.ts
@@ -8,10 +8,12 @@ import { Masto } from 'masto';
   });
 
   // Upload the image
-  const attachment = await masto.createMediaAttachment({
-    file: fs.createReadStream('../some_image.png'),
-    description: 'Some image',
-  });
+  const attachment = await masto
+    .createMediaAttachment({
+      file: fs.createReadStream('../some_image.png'),
+      description: 'Some image',
+    })
+    .then(({ id }) => masto.waitForMediaAttachment(id));
 
   // Toot!
   masto.createStatus({

--- a/src/clients/masto/__tests__/__snapshots__/masto.spec.ts.snap
+++ b/src/clients/masto/__tests__/__snapshots__/masto.spec.ts.snap
@@ -1103,6 +1103,22 @@ exports[`Masto fetchMarkers 1`] = `
 }
 `;
 
+exports[`Masto fetchMediaAttachment 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "/api/v1/media/123",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
 exports[`Masto fetchMutes 1`] = `
 [MockFunction] {
   "calls": Array [

--- a/src/clients/masto/__tests__/masto.spec.ts
+++ b/src/clients/masto/__tests__/masto.spec.ts
@@ -1009,4 +1009,10 @@ describe('Masto', () => {
     expect(mockPost).toBeCalledTimes(1);
     expect(mockPost).toMatchSnapshot();
   });
+
+  test('fetchMediaAttachment', async () => {
+    await masto.fetchMediaAttachment('123');
+    expect(mockGet).toBeCalledTimes(1);
+    expect(mockGet).toMatchSnapshot();
+  });
 });

--- a/src/entities/attachment.ts
+++ b/src/entities/attachment.ts
@@ -44,7 +44,7 @@ export interface Attachment {
   /** The type of the attachment. */
   type: AttachmentType;
   /** The location of the original full-size attachment. */
-  url: string;
+  url?: string | null;
   /** The location of a scaled-down preview of the attachment. */
   previewUrl: string;
 

--- a/src/utils/delay.ts
+++ b/src/utils/delay.ts
@@ -1,0 +1,2 @@
+export const delay = (ms: number) =>
+  new Promise((resolve) => setTimeout(() => resolve(), ms));


### PR DESCRIPTION
Partly resolves, #303 

This PR makes `Attachment.url` optional but it should've been optional since v3. thus I will not bump the major version.