### PR TITLE
Fix semver throwing on mastodon.social

### DIFF
--- a/src/clients/masto/masto.ts
+++ b/src/clients/masto/masto.ts
@@ -776,7 +776,7 @@ export class Masto extends GatewayImpl {
    */
   @available({ since: '0.0.0' })
   createMediaAttachment(params: CreateMediaAttachmentParams) {
-    const v = semver.gt(this.version, '3.1.3') ? 'v2' : 'v1';
+    const v = semver.gt(this.version, '3.1.3', { loose: true }) ? 'v2' : 'v1';
     return this.post<Attachment>(`/api/${v}/media`, params, {
       headers: { 'Content-Type': 'multipart/form-data' },
     });
@@ -1045,7 +1045,7 @@ export class Masto extends GatewayImpl {
    */
   @available({ since: '0.0.0' })
   search(params: SearchParams) {
-    const v = semver.gt(this.version, '2.4.1') ? 'v2' : 'v1';
+    const v = semver.gt(this.version, '2.4.1', { loose: true }) ? 'v2' : 'v1';
     return this.paginate<Results, typeof params>(`/api/${v}/search`, params);
   }
 

--- a/src/gateway/decorators.ts
+++ b/src/gateway/decorators.ts
@@ -28,7 +28,11 @@ export const available = ({ since, until }: AvailableParams) => (
     this: Gateway,
     ...args: Parameters<typeof original>
   ) {
-    if (since && this.version && semver.lt(this.version, since)) {
+    if (
+      since &&
+      this.version &&
+      semver.lt(this.version, since, { loose: true })
+    ) {
       throw new MastoNotFoundError(
         `${String(name)} is not available with the current ` +
           `Mastodon version ${this.version}. ` +
@@ -36,7 +40,11 @@ export const available = ({ since, until }: AvailableParams) => (
       );
     }
 
-    if (until && this.version && semver.gt(this.version, until)) {
+    if (
+      until &&
+      this.version &&
+      semver.gt(this.version, until, { loose: true })
+    ) {
       throw new MastoNotFoundError(
         `${String(name)} is not available with the current ` +
           `Mastodon version ${this.version}. ` +

--- a/src/gateway/gateway-impl.ts
+++ b/src/gateway/gateway-impl.ts
@@ -322,7 +322,11 @@ export class GatewayImpl implements Gateway {
 
     // Since v2.8.4, it is supported to pass access token with`Sec-Websocket-Protocol`
     // https://github.com/tootsuite/mastodon/pull/10818
-    if (this.accessToken && this.version && semver.gte(this.version, '2.8.4')) {
+    if (
+      this.accessToken &&
+      this.version &&
+      semver.gte(this.version, '2.8.4', { loose: true })
+    ) {
       protocols.push(this.accessToken);
     } else if (this.accessToken) {
       params.accessToken = this.accessToken;


### PR DESCRIPTION
I'm getting the following error when running masto.js on mastodon.social:

```
Invalid Version: 3.3.0rc1
TypeError: Invalid Version: 3.3.0rc1
    at new SemVer (node_modules/semver/classes/semver.js:41:13)
    at compare (node_modules/semver/functions/compare.js:3:3)
    at Object.lt (node_modules/semver/functions/lt.js:2:29)
    at Masto.descriptor.value [as createMediaAttachment] (node_modules/masto/dist/index.js:881:69)
    at doToot (src/main.ts:138:30)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
```

It looks like the version of Mastodon running on mastodon.social is `3.3.0rc1`, which isn't a valid semver string (the valid version of this would be `3.3.0-rc1`, with a hyphen). We can verify this in the node repl:

```
> const semver = require('semver')
> semver.valid('3.3.0rc1')
null
> semver.valid('3.3.0-rc1')
'3.3.0-rc1'
```

Unfortunately, the `semver` library throws when running comparison functions like `semver.lte` or `semver.gt` with an invalid version, so this broke all my apps...

The simplest fix is to pass `{ loose: true }` to any `semver` functions:

```
> const semver = require('semver')
> semver.gt('3.3.0rc1', '3.1.3')
Uncaught TypeError: Invalid Version: 3.3.0rc1
    at new SemVer (node_modules/semver/classes/semver.js:38:13)
    at compare (node_modules/semver/functions/compare.js:3:3)
    at Object.gt (node_modules/semver/functions/gt.js:2:29)
> semver.gt('3.3.0rc1', '3.1.3', { loose: true })
true
```

I've added this option to all uses of `semver` in this module.