### PR TITLE
Fix "documentation" hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ async function main() {
 main();
 ```
 
-All of available methods are described in the [documentation](https://neet.github.io/masto.js/classes/_clients_masto_masto_.masto.html). You can also refer [examples](https://github.com/neet/masto.js/tree/master/examples) on this repository.
+All of available methods are described in the [documentation](https://git.io/JUgU8). You can also refer [examples](https://github.com/neet/masto.js/tree/master/examples) on this repository.
 
 ## FAQ
 


### PR DESCRIPTION
All of available methods are described in the [documentation] points to a dead page. Updated link to go to correct documentation page.