### PR TITLE
Mastodon 3.5.0

### DIFF
--- a/src/entities/index.ts
+++ b/src/entities/index.ts
@@ -15,6 +15,7 @@ export * from './history';
 export * from './identity-proof';
 export * from './instance';
 export * from './field';
+export * from './link';
 export * from './list';
 export * from './marker';
 export * from './mention';

--- a/src/entities/index.ts
+++ b/src/entities/index.ts
@@ -28,5 +28,7 @@ export * from './results';
 export * from './scheduled-status';
 export * from './source';
 export * from './status';
+export * from './status-edit';
+export * from './status-source';
 export * from './tag';
 export * from './token';

--- a/src/entities/instance.ts
+++ b/src/entities/instance.ts
@@ -69,6 +69,8 @@ export interface Instance {
   thumbnail?: string | null;
   /** A user that can be contacted, as an alternative to `email`. */
   contactAccount?: Account | null;
+
+  rules?: InstanceRule[] | null;
 }
 
 export interface InstanceURLs {
@@ -83,4 +85,9 @@ export interface InstanceStats {
   statusCount: number;
   /** Domains federated with this instance. Number. */
   domainCount: number;
+}
+
+export interface InstanceRule {
+  id: string;
+  text: string;
 }

--- a/src/entities/link.ts
+++ b/src/entities/link.ts
@@ -1,0 +1,6 @@
+import { Card } from './card';
+import { History } from './history';
+
+export interface Link extends Card {
+  history: History[];
+}

--- a/src/entities/status-edit.ts
+++ b/src/entities/status-edit.ts
@@ -1,17 +1,12 @@
-import { Account } from './account';
-import { Attachment } from './attachment';
-import { Emoji } from './emoji';
-import { Poll } from './poll';
+import { Status } from './status';
 
-export interface StatusEdit {
-  account: Account;
-
-  content: string;
-  spoilerText: string;
-  sensitive: boolean;
-  createdAt: string;
-  orderedMediaAttachments: Attachment[];
-  emojis: Emoji[];
-
-  poll?: Poll[] | null;
-}
+export type StatusEdit = Pick<
+  Status,
+  | 'content'
+  | 'spoilerText'
+  | 'sensitive'
+  | 'createdAt'
+  | 'account'
+  | 'mediaAttachments'
+  | 'emojis'
+>;

--- a/src/entities/status-edit.ts
+++ b/src/entities/status-edit.ts
@@ -1,0 +1,17 @@
+import { Account } from './account';
+import { Attachment } from './attachment';
+import { Emoji } from './emoji';
+import { Poll } from './poll';
+
+export interface StatusEdit {
+  account: Account;
+
+  content: string;
+  spoilerText: string;
+  sensitive: boolean;
+  createdAt: string;
+  orderedMediaAttachments: Attachment[];
+  emojis: Emoji[];
+
+  poll?: Poll[] | null;
+}

--- a/src/entities/status-source.ts
+++ b/src/entities/status-source.ts
@@ -1,0 +1,5 @@
+export interface StatusSource {
+  id: string;
+  text: string;
+  spoilerText: string;
+}

--- a/src/entities/token.ts
+++ b/src/entities/token.ts
@@ -1,7 +1,6 @@
 const enum ScopeVerb {
   Read = 'read',
   Write = 'write',
-  Follow = 'follow',
   Push = 'push',
 }
 

--- a/src/paginator.ts
+++ b/src/paginator.ts
@@ -2,7 +2,8 @@ import { Http } from './http';
 import { Response } from './http/http';
 
 export class Paginator<Params, Result>
-  implements AsyncIterableIterator<Result> {
+  implements AsyncIterableIterator<Result>
+{
   private nextUrl?: string;
   private nextParams?: Params;
 

--- a/src/repositories/account-repository.ts
+++ b/src/repositories/account-repository.ts
@@ -360,4 +360,22 @@ export class AccountRepository
   lookup(params: LookupAccountParams): Promise<Account> {
     return this.http.get('/api/v1/accounts/lookup', params);
   }
+
+  /**
+   * TODO: stub
+   * @returns Accounts
+   */
+  @version({ since: '3.5.0' })
+  fetchFamiliarFollowers(): Promise<Account[]> {
+    return this.http.get(`/api/v1/accounts/familiar_followers`);
+  }
+
+  /**
+   * @param id ID of the account
+   * @returns N/A
+   */
+  @version({ since: '3.5.0' })
+  removeFromFollowers(id: string): Promise<void> {
+    return this.http.post(`/api/v1/accounts/${id}/remove_from_followers`);
+  }
 }

--- a/src/repositories/notification-repository.ts
+++ b/src/repositories/notification-repository.ts
@@ -5,6 +5,8 @@ import { Paginator } from '../paginator';
 import { DefaultPaginationParams, Repository } from '../repository';
 
 export interface FetchNotificationsParams extends DefaultPaginationParams {
+  /** Instead of specifying every known type to exclude, you can specify only the types you want. */
+  readonly types?: NotificationType[] | null;
   /** ID of the account */
   readonly accountId?: string | null;
   /** Array of notifications to exclude (Allowed values: "follow", "favourite", "reblog", "mention") */

--- a/src/repositories/report-repository.ts
+++ b/src/repositories/report-repository.ts
@@ -1,6 +1,8 @@
 import { version } from '../decorators';
 import { Http } from '../http';
 
+export type ReportCategory = 'spam' | 'violation' | 'other';
+
 export interface ReportAccountParams {
   /** ID of the account to report */
   readonly accountId: string;
@@ -10,6 +12,10 @@ export interface ReportAccountParams {
   readonly comment?: string | null;
   /** If the account is remote, should the report be forwarded to the remote admin? */
   readonly forward?: boolean | null;
+  /** category can be one of: spam, violation, other (default) */
+  readonly category?: ReportCategory | null;
+  /** must reference rules returned in GET /api/v1/instance */
+  readonly ruleIds?: string[] | null;
 }
 
 export class ReportRepository {

--- a/src/repositories/status-repository.ts
+++ b/src/repositories/status-repository.ts
@@ -1,3 +1,4 @@
+import { StatusEdit } from 'src/entities/status-edit';
 import { deprecated, version } from '../decorators';
 import { Account, Card, Context, Status, StatusVisibility } from '../entities';
 import { Http } from '../http';
@@ -49,6 +50,8 @@ export type CreateStatusParams =
   | CreateStatusParamsWithStatus
   | CreateStatusParamsWithMediaIds;
 
+export type UpdateStatusParams = CreateStatusParams;
+
 export interface ReblogStatusParams {
   /** any visibility except limited or direct (i.e. public, unlisted, private). Defaults to public. Currently unused in UI. */
   readonly visibility: StatusVisibility;
@@ -84,6 +87,17 @@ export class StatusRepository implements Repository<Status> {
     }
 
     return this.http.post('/api/v1/statuses', params);
+  }
+
+  /**
+   * Update a status
+   * @param params Parameters
+   * @return Status. When scheduled_at is present, ScheduledStatus is returned instead.
+   * @see https://docs.joinmastodon.org/api/rest/statuses/#post-api-v1-statuses
+   */
+  @version({ since: '0.0.0' })
+  update(params: UpdateStatusParams): Promise<Status> {
+    return this.http.put('/api/v1/statuses', params);
   }
 
   /**
@@ -251,5 +265,10 @@ export class StatusRepository implements Repository<Status> {
   @version({ since: '3.1.0' })
   unbookmark(id: string): Promise<Status> {
     return this.http.post(`/api/v1/statuses/${id}/unbookmark`);
+  }
+
+  @version({ since: '3.5.0' })
+  fetchHistory(id: string): Promise<StatusEdit[]> {
+    return this.http.get(`/api/v1/statuses/${id}/history`);
   }
 }

--- a/src/repositories/status-repository.ts
+++ b/src/repositories/status-repository.ts
@@ -1,6 +1,13 @@
-import { StatusEdit } from 'src/entities/status-edit';
 import { deprecated, version } from '../decorators';
-import { Account, Card, Context, Status, StatusVisibility } from '../entities';
+import {
+  Account,
+  Card,
+  Context,
+  Status,
+  StatusEdit,
+  StatusSource,
+  StatusVisibility,
+} from '../entities';
 import { Http } from '../http';
 import { Repository } from '../repository';
 
@@ -95,9 +102,9 @@ export class StatusRepository implements Repository<Status> {
    * @return Status. When scheduled_at is present, ScheduledStatus is returned instead.
    * @see https://docs.joinmastodon.org/api/rest/statuses/#post-api-v1-statuses
    */
-  @version({ since: '0.0.0' })
-  update(params: UpdateStatusParams): Promise<Status> {
-    return this.http.put('/api/v1/statuses', params);
+  @version({ since: '3.5.0' })
+  update(id: string, params: UpdateStatusParams): Promise<Status> {
+    return this.http.put(`/api/v1/statuses/${id}`, params);
   }
 
   /**
@@ -270,5 +277,10 @@ export class StatusRepository implements Repository<Status> {
   @version({ since: '3.5.0' })
   fetchHistory(id: string): Promise<StatusEdit[]> {
     return this.http.get(`/api/v1/statuses/${id}/history`);
+  }
+
+  @version({ since: '3.5.0' })
+  fetchSource(id: string): Promise<StatusSource> {
+    return this.http.get(`/api/v1/statuses/${id}/source`);
   }
 }

--- a/src/repositories/trend-repository.ts
+++ b/src/repositories/trend-repository.ts
@@ -1,7 +1,8 @@
 import { version } from '../decorators';
-import { Tag } from '../entities';
+import { Link, Status, Tag } from '../entities';
 import { Http } from '../http';
-import { Repository } from '../repository';
+import { Paginator } from '../paginator';
+import { DefaultPaginationParams, Repository } from '../repository';
 
 export interface FetchTrendsParams {
   /** Maximum number of results to return. Defaults to 10. */
@@ -11,6 +12,28 @@ export interface FetchTrendsParams {
 export class TrendRepository implements Repository<Tag> {
   constructor(private readonly http: Http, readonly version: string) {}
 
+  get statuses(): Paginator<DefaultPaginationParams, Status[]> {
+    return this.getStatuses();
+  }
+
+  get links(): Paginator<DefaultPaginationParams, Link[]> {
+    return this.getLinks();
+  }
+
+  @version({ since: '3.5.0' })
+  getStatuses(
+    params?: DefaultPaginationParams,
+  ): Paginator<DefaultPaginationParams, Status[]> {
+    return new Paginator(this.http, '/api/v1/trends/statuses', params);
+  }
+
+  @version({ since: '3.5.0' })
+  getLinks(
+    params?: DefaultPaginationParams,
+  ): Paginator<DefaultPaginationParams, Link[]> {
+    return new Paginator(this.http, '/api/v1/trends/links', params);
+  }
+
   /**
    * Tags that are being used more frequently within the past week.
    * @param params Parameters
@@ -19,6 +42,6 @@ export class TrendRepository implements Repository<Tag> {
    */
   @version({ since: '3.0.0' })
   fetchAll(params?: FetchTrendsParams): Promise<Tag[]> {
-    return this.http.get<Tag[]>('/api/v1/trends', params);
+    return this.http.get<Tag[]>('/api/v1/trends/tags', params);
   }
 }

--- a/src/ws/ws.ts
+++ b/src/ws/ws.ts
@@ -14,17 +14,14 @@ export interface EventTypeMap {
   filters_changed: [];
   /** Status added to a conversation */
   conversation: [Conversation];
+  /** Status updated */
+  'status.update': [Status];
   /** for RxJS' `fromEvent` compatibility */
   [K: string]: unknown[];
 }
 
 /** Supported event names */
-export type EventType =
-  | 'update'
-  | 'delete'
-  | 'notification'
-  | 'filters_changed'
-  | 'conversation';
+export type EventType = keyof EventTypeMap;
 
 /** Mastodon event */
 export interface Event {


### PR DESCRIPTION
https://github.com/mastodon/mastodon/releases/tag/v3.5.0rc1

- [x] Stauts apis
  - [x] PUT /api/v1/statuses/:id
  - [x] GET /api/v1/statuses/:id/history
  - [x] GET /api/v1/statuses/:id/source
  - [x] `update` streaming API event
- [ ] Trend apis
  - [x] GET /api/v1/trends/links
  - [x] GET /api/v1/trends/statuses
  - [x] GET /api/v1/trends/tags (alias of GET /api/v1/trends)
  - [x] GET /api/v1/admin/trends/links
  - [x] GET /api/v1/admin/trends/statuses
  - [x] GET /api/v1/admin/trends/tags
- [ ] Admin graph apis
  - [ ] POST /api/v1/admin/measures
  - [ ] POST /api/v1/admin/dimensions
  - [ ] POST /api/v1/admin/retention
- [x] GET /api/v1/accounts/familiar_followers 
- [x] POST /api/v1/accounts/:id/remove_from_followers
- [x] Rule ID of POST /api/v1/reports
- [ ] lang param 
- [x] types of GET /api/v1/notifications 
- [ ] Sign up streaming api event admin.sign_up
- [x] deprecate GET /api/v1/trends/tags
- [x] deprecate follow