### PR TITLE
Fix several bugs on `HttpNativeImpl`

### DIFF
--- a/src/http/base-http.ts
+++ b/src/http/base-http.ts
@@ -1,5 +1,5 @@
 import { MastoConfig } from '../config';
-import { Serializer } from '../serializers';
+import { MimeType, Serializer } from '../serializers';
 import { Data, Headers, Http, Request, Response } from './http';
 
 export abstract class BaseHttp implements Http {
@@ -26,6 +26,18 @@ export abstract class BaseHttp implements Http {
     return `${this.config.url}${path}${
       searchParams !== '' ? `?${searchParams}` : ''
     }`;
+  }
+
+  getContentType(headers: Headers | globalThis.Headers): MimeType | undefined {
+    const contentType =
+      headers instanceof globalThis.Headers
+        ? headers.get('Content-Type')
+        : headers['Content-Type'];
+    if (typeof contentType != 'string') {
+      return undefined;
+    }
+
+    return contentType.replace(/\s*;.*$/, '') as MimeType;
   }
 
   get<T>(url: string, data?: Data, init: Partial<Request> = {}): Promise<T> {

--- a/src/http/http-axios-impl.ts
+++ b/src/http/http-axios-impl.ts
@@ -35,7 +35,7 @@ export class HttpAxiosImpl extends BaseHttp implements Http {
       },
       transformResponse: (data, headers) =>
         this.serializer.deserialize(
-          headers['Content-Type'] ?? 'application/json',
+          this.getContentType(headers) ?? 'application/json',
           data,
         ),
       paramsSerializer: (params) =>

--- a/src/http/http-native-impl.ts
+++ b/src/http/http-native-impl.ts
@@ -37,11 +37,10 @@ export class HttpNativeImpl extends BaseHttp implements Http {
         body: body as string,
       });
       const text = await response.text();
+      const contentType =
+        this.getContentType(response.headers) ?? 'application/json';
 
-      return this.serializer.deserialize(
-        response.headers.get('Content-Type') as MimeType,
-        text,
-      );
+      return this.serializer.deserialize(contentType, text);
     } catch (e) {
       if (!(e instanceof Response)) {
         throw e;


### PR DESCRIPTION
### Trim content type parameters from HTTP responses

Previously, `request()` method from `HttpAxiosImpl` & `HttpNativeImpl` sometimes threw an error like below:

    Uncaught (in promise) Error: Unknown content type application/json; charset=utf-8, {...}

It happened when a response from server contains `Content-Type` header with some parameters, e.g., `application/json; charset=utf-8`.

It might be better to make `deserialize()` method from `SerializerNodejsImpl` & `SerializerNativeImpl` to trim parameters from their input, but I trim parameters from response content types instead.  If you leave a comment on this I'm going to address that.

### On `HttpNativeImpl.request<T>()`'s return type

Also there's one more fix on `HttpNativeImpl.request<T>()` method.  It should return `Response<T>`, but actually returned `T` instead.  I addressed this bug as well.

### Let `HttpNativeImpl` set an appropriate boundary for `multipart/form-data`

The standard `fetch()` API automatically configures an [arbitrary boundary][1] for `multipart/form-data` when its body is `FormData`.  However, the boundary can be omitted if `Content-Type` header is manually set.  I made `HttpNativeImpl` to leave `Content-Type` header unset when it's `multipart/form-data` so that the underlying `fetch()` can determine an appropriate boundary for the form data.

[1]: https://datatracker.ietf.org/doc/html/rfc7578#section-4.1