### PR TITLE
revert to reading headers for React Native compatibility

### DIFF
--- a/src/http/http-native-impl.ts
+++ b/src/http/http-native-impl.ts
@@ -90,9 +90,9 @@ export class HttpNativeImpl extends BaseHttp implements Http {
 
   private static toHeaders(headers: globalThis.Headers): Headers {
     const result: Record<string, unknown> = {};
-    for (const [key, value] of Object.entries(headers)) {
-      result[headerCase(key)] = value;
-    }
+    headers.forEach((value, key) => {
+        result[headerCase(key)] = value;
+    });
     return result as Headers;
   }
 


### PR DESCRIPTION
An older version of masto.js worked pretty fine with React Native, but this compatibility broke recently.

Reverting the way how headers are mapped fixes the issue.