### PR TITLE
fix: Use `params` instead of `data` in pagination

### DIFF
--- a/src/paginator.ts
+++ b/src/paginator.ts
@@ -28,7 +28,7 @@ export class Paginator<Params, Result>
       method: 'get',
       // if no params specified, use link header
       url: params ? this.initialUrl : this.nextUrl,
-      data: params ?? this.nextParams,
+      params: params ?? this.nextParams,
     });
 
     this.nextUrl = this.pluckNext(response.headers?.link as string);


### PR DESCRIPTION
Close #686 