### PR TITLE
fix: read next link from response

### DIFF
--- a/src/http/http.ts
+++ b/src/http/http.ts
@@ -1,4 +1,4 @@
-export type Headers = Record<string, unknown>;
+export type Headers = Record<string, string>;
 export type Data = unknown;
 
 export type Request = {

--- a/src/http/http.ts
+++ b/src/http/http.ts
@@ -1,4 +1,4 @@
-export type Headers = Record<string, string>;
+export type Headers = Record<string, unknown>;
 export type Data = unknown;
 
 export type Request = {

--- a/src/paginator.spec.ts
+++ b/src/paginator.spec.ts
@@ -42,4 +42,17 @@ describe('Paginator', () => {
       url: '/api/v1/timelines/home?max_id=109382006402042919',
     });
   });
+
+  it('returns done when next link does not exist', async () => {
+    const http = new Test();
+    http.request.mockReturnValue({
+      headers: {},
+    });
+    const paginator = new Paginator(http, '/v1/api/timelines');
+    await paginator.next();
+    const result = await paginator.next();
+    expect(result).toEqual({
+      done: true,
+    });
+  });
 });

--- a/src/paginator.spec.ts
+++ b/src/paginator.spec.ts
@@ -1,0 +1,45 @@
+import { BaseHttp } from './http/base-http';
+import { Paginator } from './paginator';
+import { SerializerNodejsImpl } from './serializers';
+
+class Test extends BaseHttp {
+  config = {
+    url: 'https://mastodon.social',
+    accessToken: 'token',
+  };
+  request = jest.fn();
+  serializer = new SerializerNodejsImpl();
+}
+
+describe('Paginator', () => {
+  it('sends a request', async () => {
+    const http = new Test();
+    http.request.mockReturnValue({ headers: {} });
+    const paginator = new Paginator(http, '/v1/api/timelines', {
+      foo: 'bar',
+    });
+    await paginator.next();
+    expect(http.request.mock.calls[0][0]).toEqual({
+      method: 'get',
+      url: '/v1/api/timelines',
+      params: { foo: 'bar' },
+    });
+  });
+
+  it('parses the next url', async () => {
+    const http = new Test();
+    http.request.mockReturnValue({
+      headers: {
+        Link: '<https://mastodon.social/api/v1/timelines/home?max_id=109382006402042919>; rel="next", <https://mastodon.social/api/v1/timelines/home?min_id=109382039876197520>; rel="prev"',
+      },
+    });
+    const paginator = new Paginator(http, '/v1/api/timelines');
+    await paginator.next();
+    await paginator.next();
+    expect(http.request.mock.calls[1][0]).toEqual({
+      method: 'get',
+      params: undefined,
+      url: '/api/v1/timelines/home?max_id=109382006402042919',
+    });
+  });
+});

--- a/src/paginator.ts
+++ b/src/paginator.ts
@@ -15,8 +15,10 @@ export class Paginator<Params, Result>
     this.nextParams = initialParams;
   }
 
-  private pluckNext = (link: string) => {
-    return link?.match(/<(.+?)>; rel="next"/)?.[1];
+  private pluckNext = (link: string | undefined) => {
+    return link
+      ?.match(/<(.+?)>; rel="next"/)?.[1]
+      .replace(/^https?:\/\/[^/]+/, '');
   };
 
   async next(params?: Params): Promise<IteratorResult<Result>> {
@@ -31,7 +33,7 @@ export class Paginator<Params, Result>
       params: params ?? this.nextParams,
     });
 
-    this.nextUrl = this.pluckNext(response.headers?.link as string);
+    this.nextUrl = this.pluckNext(response.headers?.Link);
 
     return {
       done: false,

--- a/src/paginator.ts
+++ b/src/paginator.ts
@@ -15,9 +15,9 @@ export class Paginator<Params, Result>
     this.nextParams = initialParams;
   }
 
-  private pluckNext = (link: string | undefined) => {
+  private pluckNext = (link: string) => {
     return link
-      ?.match(/<(.+?)>; rel="next"/)?.[1]
+      .match(/<(.+?)>; rel="next"/)?.[1]
       .replace(/^https?:\/\/[^/]+/, '');
   };
 
@@ -33,7 +33,10 @@ export class Paginator<Params, Result>
       params: params ?? this.nextParams,
     });
 
-    this.nextUrl = this.pluckNext(response.headers?.Link);
+    this.nextUrl =
+      typeof response.headers?.Link === 'string'
+        ? this.pluckNext(response.headers.Link)
+        : undefined;
 
     return {
       done: false,


### PR DESCRIPTION
`paginator.next()` isn't working with React Natives fetch, because it includes the domain. Therefore I changed the `pluckNext` function so it doesn't include the domain. Also I added a test and fixed the header type.