### PR TITLE
fix: Correct iterable used when fetching following accounts

### DIFF
--- a/src/repositories/account-repository.ts
+++ b/src/repositories/account-repository.ts
@@ -202,7 +202,7 @@ export class AccountRepository
     id: string,
     params: DefaultPaginationParams = {},
   ): Promise<IteratorResult<Account[]>> {
-    return this.getFollowersIterable(id, params).next();
+    return this.getFollowingIterable(id, params).next();
   }
 
   /**


### PR DESCRIPTION
This PR fixes an incorrect call to get following accounts of an account