### PR TITLE
chore: Rename getXXXIterable to iterateXXX

### DIFF
--- a/examples/timeline-with-iterable.ts
+++ b/examples/timeline-with-iterable.ts
@@ -17,7 +17,7 @@ const main = async () => {
   }
 
   // You can also use `for-await-of` syntax to iterate over the timeline
-  for await (const statuses of masto.timelines.getPublicIterable()) {
+  for await (const statuses of masto.timelines.iteratePublic()) {
     statuses.forEach((status) => {
       masto.statuses.favourite(status.id);
     });

--- a/src/repositories/account-repository.ts
+++ b/src/repositories/account-repository.ts
@@ -103,7 +103,7 @@ export class AccountRepository
   ) {}
 
   @version({ since: '0.0.0' })
-  getFollowersIterable(
+  iterateFollowers(
     id: string,
     params: DefaultPaginationParams,
   ): Paginator<DefaultPaginationParams, Account[]> {
@@ -111,7 +111,7 @@ export class AccountRepository
   }
 
   @version({ since: '0.0.0' })
-  getFollowingIterable(
+  iterateFollowing(
     id: string,
     params: DefaultPaginationParams,
   ): Paginator<DefaultPaginationParams, Account[]> {
@@ -119,12 +119,19 @@ export class AccountRepository
   }
 
   @version({ since: '0.0.0' })
-  getStatusesIterable(
+  iterateStatuses(
     id: string,
     params: FetchAccountStatusesParams,
   ): Paginator<FetchAccountStatusesParams, Status[]> {
     return new Paginator(this.http, `/api/v1/accounts/${id}/statuses`, params);
   }
+
+  /** @deprecated Use `iterateFollowers` */
+  getFollowersIterable = this.iterateFollowers.bind(this);
+  /** @deprecated Use `iterateFollowing` */
+  getFollowingIterable = this.iterateFollowing.bind(this);
+  /** @deprecated Use `iterateStatuses` */
+  getStatusesIterable = this.iterateStatuses.bind(this);
 
   // ====
 
@@ -188,7 +195,7 @@ export class AccountRepository
     id: string,
     params: DefaultPaginationParams = {},
   ): Promise<IteratorResult<Account[]>> {
-    return this.getFollowersIterable(id, params).next();
+    return this.iterateFollowers(id, params).next();
   }
 
   /**
@@ -202,7 +209,7 @@ export class AccountRepository
     id: string,
     params: DefaultPaginationParams = {},
   ): Promise<IteratorResult<Account[]>> {
-    return this.getFollowingIterable(id, params).next();
+    return this.iterateFollowing(id, params).next();
   }
 
   /**
@@ -216,7 +223,7 @@ export class AccountRepository
     id: string,
     params: DefaultPaginationParams = {},
   ): Promise<IteratorResult<Status[]>> {
-    return this.getStatusesIterable(id, params).next();
+    return this.iterateStatuses(id, params).next();
   }
 
   /**

--- a/src/repositories/block-repository.ts
+++ b/src/repositories/block-repository.ts
@@ -22,7 +22,7 @@ export class BlockRepository extends IterableRepository<Account> {
    * @see https://docs.joinmastodon.org/methods/accounts/blocks/
    */
   @version({ since: '0.0.0' })
-  override getIterator(
+  override iterate(
     params?: DefaultPaginationParams,
   ): Paginator<DefaultPaginationParams, Account[]> {
     return new Paginator(this.http, `/api/v1/blocks`, params);

--- a/src/repositories/bookmark-repository.ts
+++ b/src/repositories/bookmark-repository.ts
@@ -22,7 +22,7 @@ export class BookmarkRepository extends IterableRepository<Status> {
    * @see https://docs.joinmastodon.org/methods/accounts/bookmarks/
    */
   @version({ since: '3.1.0' })
-  override getIterator(
+  override iterate(
     params?: DefaultPaginationParams,
   ): Paginator<DefaultPaginationParams, Status[]> {
     return new Paginator(this.http, '/api/v1/bookmarks', params);

--- a/src/repositories/conversation-repository.ts
+++ b/src/repositories/conversation-repository.ts
@@ -22,7 +22,7 @@ export class ConversationRepository extends IterableRepository<Conversation> {
    * @see https://docs.joinmastodon.org/methods/timelines/conversations/
    */
   @version({ since: '2.6.0' })
-  getIterator(
+  iterate(
     params?: DefaultPaginationParams,
   ): Paginator<DefaultPaginationParams, Conversation[]> {
     return new Paginator(this.http, '/api/v1/conversations', params);

--- a/src/repositories/domain-block-repository.ts
+++ b/src/repositories/domain-block-repository.ts
@@ -21,7 +21,7 @@ export class DomainBlockRepository extends IterableRepository<string> {
    * @see https://docs.joinmastodon.org/methods/accounts/domain_blocks/
    */
   @version({ since: '1.4.0' })
-  getIterator(
+  iterate(
     params?: DefaultPaginationParams,
   ): Paginator<DefaultPaginationParams, string[]> {
     return new Paginator(this.http, `/api/v1/domain_blocks`, params);

--- a/src/repositories/endorsement-repository.ts
+++ b/src/repositories/endorsement-repository.ts
@@ -21,7 +21,7 @@ export class EndorsementRepository extends IterableRepository<Account> {
    * @see https://docs.joinmastodon.org/methods/accounts/endorsements/
    */
   @version({ since: '2.5.0' })
-  getIterator(
+  iterate(
     params?: DefaultPaginationParams,
   ): Paginator<DefaultPaginationParams, Account[]> {
     return new Paginator(this.http, `/api/v1/endorsements`, params);

--- a/src/repositories/favourite-repository.ts
+++ b/src/repositories/favourite-repository.ts
@@ -22,7 +22,7 @@ export class FavouriteRepository extends IterableRepository<Status> {
    * @see https://docs.joinmastodon.org/methods/accounts/favourites/
    */
   @version({ since: '0.0.0' })
-  getIterator(
+  iterate(
     params?: DefaultPaginationParams,
   ): Paginator<DefaultPaginationParams, Status[]> {
     return new Paginator(this.http, `/api/v1/favourites`, params);

--- a/src/repositories/follow-request-repository.ts
+++ b/src/repositories/follow-request-repository.ts
@@ -22,7 +22,7 @@ export class FollowRequestRepository extends IterableRepository<Account> {
    * @see https://docs.joinmastodon.org/methods/accounts/follow_requests/
    */
   @version({ since: '0.0.0' })
-  getIterator(
+  iterate(
     params?: DefaultPaginationParams,
   ): Paginator<DefaultPaginationParams, Account[]> {
     return new Paginator(this.http, `/api/v1/follow_requests`, params);

--- a/src/repositories/followed-tag-repository.ts
+++ b/src/repositories/followed-tag-repository.ts
@@ -16,7 +16,7 @@ export class FollowedTagRepository extends IterableRepository<Tag> {
   }
 
   @version({ since: '4.0.0' })
-  getIterator(
+  iterate(
     params?: DefaultPaginationParams | undefined,
   ): AsyncIterableIterator<Tag[]> {
     return new Paginator(this.http, '/api/v1/followed_tags', params);

--- a/src/repositories/iterable-repository.ts
+++ b/src/repositories/iterable-repository.ts
@@ -8,13 +8,19 @@ export abstract class IterableRepository<
   RMany = DefaultPaginationParams,
 > implements Repository<T, C, U, R, RMany>
 {
-  abstract getIterator(params?: RMany): AsyncIterableIterator<T[]>;
+  abstract iterate(params?: RMany): AsyncIterableIterator<T[]>;
+
+  /** @deprecated Use `iterate` instead */
+  getIterator = this.iterate.bind(this);
 
   fetchMany(params?: RMany): Promise<IteratorResult<T[]>> {
-    return this.getIterator(params).next();
+    return this.iterate(params).next();
   }
 
   async *[Symbol.asyncIterator](): AsyncIterableIterator<T[]> {
-    yield* this.getIterator != undefined ? this.getIterator() : [];
+    if (this.iterate == undefined) {
+      yield* [];
+    }
+    yield* this.iterate();
   }
 }

--- a/src/repositories/list-repository.ts
+++ b/src/repositories/list-repository.ts
@@ -25,12 +25,15 @@ export class ListRepository
   ) {}
 
   @version({ since: '2.1.0' })
-  getAccountIterator(
+  iterateAccounts(
     id: string,
     params?: DefaultPaginationParams,
   ): Paginator<DefaultPaginationParams, Account[]> {
     return new Paginator(this.http, `/api/v1/lists/${id}/accounts`, params);
   }
+
+  /** @deprecated Use `iterateAccounts` instead */
+  getAccountIterator = this.iterateAccounts.bind(this);
 
   /**
    * Fetch the list with the given ID. Used for verifying the title of a list.
@@ -98,7 +101,7 @@ export class ListRepository
     id: string,
     params?: DefaultPaginationParams,
   ): Promise<IteratorResult<Account[]>> {
-    return this.getAccountIterator(id, params).next();
+    return this.iterateAccounts(id, params).next();
   }
 
   /**

--- a/src/repositories/mutes-repository.ts
+++ b/src/repositories/mutes-repository.ts
@@ -22,7 +22,7 @@ export class MuteRepository extends IterableRepository<Account> {
    * @see https://docs.joinmastodon.org/methods/accounts/mutes/
    */
   @version({ since: '0.0.0' })
-  getIterator(
+  iterate(
     params?: DefaultPaginationParams,
   ): Paginator<DefaultPaginationParams, Account[]> {
     return new Paginator(this.http, '/api/v1/mutes', params);

--- a/src/repositories/notification-repository.ts
+++ b/src/repositories/notification-repository.ts
@@ -33,7 +33,7 @@ export class NotificationsRepository extends IterableRepository<Notification> {
    * @see https://docs.joinmastodon.org/methods/notifications/
    */
   @version({ since: '0.0.0' })
-  getIterator(
+  iterate(
     params?: FetchNotificationsParams,
   ): Paginator<FetchNotificationsParams, Notification[]> {
     return new Paginator(this.http, '/api/v1/notifications', params);

--- a/src/repositories/repository.ts
+++ b/src/repositories/repository.ts
@@ -18,7 +18,7 @@ export interface Repository<
 > {
   readonly [Symbol.asyncIterator]?: () => AsyncIterableIterator<Entity[]>;
 
-  readonly getIterator?: (
+  readonly iterate?: (
     params?: PaginationParams,
   ) => AsyncIterableIterator<Entity[]>;
 

--- a/src/repositories/scheduled-statuses-repository.ts
+++ b/src/repositories/scheduled-statuses-repository.ts
@@ -27,7 +27,7 @@ export class ScheduledStatusesRepository extends IterableRepository<ScheduledSta
    * @see https://docs.joinmastodon.org/methods/statuses/scheduled_statuses/
    */
   @version({ since: '2.7.0' })
-  getIterator(
+  iterate(
     params?: DefaultPaginationParams,
   ): Paginator<DefaultPaginationParams, ScheduledStatus[]> {
     return new Paginator(this.http, '/api/v1/scheduled_statuses', params);

--- a/src/repositories/timelines-repository.ts
+++ b/src/repositories/timelines-repository.ts
@@ -21,30 +21,22 @@ export class TimelinesRepository {
     readonly config: MastoConfig,
   ) {}
 
-  get home(): Paginator<FetchTimelineParams, Status[]> {
-    return this.getHomeIterable();
-  }
-
-  get public(): Paginator<FetchTimelineParams, Status[]> {
-    return this.getPublicIterable();
-  }
-
   @version({ since: '0.0.0' })
-  getHomeIterable(
+  iterateHome(
     params?: FetchTimelineParams,
   ): Paginator<FetchTimelineParams, Status[]> {
     return new Paginator(this.http, '/api/v1/timelines/home', params);
   }
 
   @version({ since: '0.0.0' })
-  getPublicIterable(
+  iteratePublic(
     params?: FetchTimelineParams,
   ): Paginator<FetchTimelineParams, Status[]> {
     return new Paginator(this.http, '/api/v1/timelines/public', params);
   }
 
   @version({ since: '0.0.0' })
-  getHashtagIterable(
+  iterateHashtag(
     hashtag: string,
     params?: FetchTimelineParams,
   ): Paginator<FetchTimelineParams, Status[]> {
@@ -52,7 +44,7 @@ export class TimelinesRepository {
   }
 
   @version({ since: '2.1.0' })
-  getListIterable(
+  iterateList(
     id: string,
     params?: FetchTimelineParams,
   ): Paginator<FetchTimelineParams, Status[]> {
@@ -61,7 +53,7 @@ export class TimelinesRepository {
 
   @deprecated('Use conversations API instead')
   @version({ since: '0.0.0', until: '2.9.3' })
-  getDirectIterable(
+  iterateDirect(
     params?: FetchTimelineParams,
   ): Paginator<FetchTimelineParams, Status[]> {
     return new Paginator(this.http, '/api/v1/timelines/direct', params);
@@ -77,7 +69,7 @@ export class TimelinesRepository {
    */
   @version({ since: '0.0.0' })
   fetchHome(params?: FetchTimelineParams): Promise<IteratorResult<Status[]>> {
-    return this.getHomeIterable(params).next();
+    return this.iterateHome(params).next();
   }
 
   /**
@@ -88,7 +80,7 @@ export class TimelinesRepository {
    */
   @version({ since: '0.0.0' })
   fetchPublic(params?: FetchTimelineParams): Promise<IteratorResult<Status[]>> {
-    return this.getPublicIterable(params).next();
+    return this.iteratePublic(params).next();
   }
 
   /**
@@ -103,7 +95,7 @@ export class TimelinesRepository {
     hashtag: string,
     params?: FetchTimelineParams,
   ): Promise<IteratorResult<Status[]>> {
-    return this.getHashtagIterable(hashtag, params).next();
+    return this.iterateHashtag(hashtag, params).next();
   }
 
   /**
@@ -118,7 +110,7 @@ export class TimelinesRepository {
     id: string,
     params?: FetchTimelineParams,
   ): Promise<IteratorResult<Status[]>> {
-    return this.getListIterable(id, params).next();
+    return this.iterateList(id, params).next();
   }
 
   /**
@@ -130,23 +122,33 @@ export class TimelinesRepository {
   @deprecated('Use conversations API instead')
   @version({ since: '0.0.0', until: '2.9.3' })
   fetchDirect(params?: FetchTimelineParams): Promise<IteratorResult<Status[]>> {
-    return this.getDirectIterable(params).next();
+    return this.iterateDirect(params).next();
   }
 
   // ====
 
-  /**
-   * @deprecated Use getHashtagIterable instead.
-   */
-  getTagIterable = this.getHashtagIterable.bind(this);
-
-  /**
-   * @deprecated Use getListIterable instead.
-   */
-  getList = this.getListIterable.bind(this);
-
-  /**
-   * @deprecated Use getDirectIterable instead.
-   */
-  getDirect = this.getDirectIterable.bind(this);
+  /** @deprecated Use `iterateHashtag` instead. */
+  getTagIterable = this.iterateHashtag.bind(this);
+  /** @deprecated Use `iterateList` instead. */
+  getList = this.iterateList.bind(this);
+  /** @deprecated Use `iterateDirect` instead. */
+  getDirect = this.iterateDirect.bind(this);
+  /** @deprecated Use `iterateHome` instead` */
+  get home(): Paginator<FetchTimelineParams, Status[]> {
+    return this.iterateHome();
+  }
+  /** @deprecated Use `iteratePublic` instead` */
+  get public(): Paginator<FetchTimelineParams, Status[]> {
+    return this.iteratePublic();
+  }
+  /** @deprecated Use `iterateHome` instead` */
+  getHomeIterable = this.iterateHome.bind(this);
+  /** @deprecated Use `iteratePublic` instead` */
+  getPublicIterable = this.iteratePublic.bind(this);
+  /** @deprecated Use `iterateHashtag` instead` */
+  getHashtagIterable = this.iterateHashtag.bind(this);
+  /** @deprecated Use `iterateList` instead` */
+  getListIterable = this.iterateList.bind(this);
+  /** @deprecated Use `iterateDirect` instead` */
+  getDirectIterable = this.iterateDirect.bind(this);
 }

--- a/src/repositories/timelines-repository.ts
+++ b/src/repositories/timelines-repository.ts
@@ -59,6 +59,14 @@ export class TimelinesRepository {
     return new Paginator(this.http, '/api/v1/timelines/direct', params);
   }
 
+  get home(): Paginator<FetchTimelineParams, Status[]> {
+    return this.iterateHome();
+  }
+
+  get public(): Paginator<FetchTimelineParams, Status[]> {
+    return this.iteratePublic();
+  }
+
   // ====
 
   /**
@@ -133,14 +141,6 @@ export class TimelinesRepository {
   getList = this.iterateList.bind(this);
   /** @deprecated Use `iterateDirect` instead. */
   getDirect = this.iterateDirect.bind(this);
-  /** @deprecated Use `iterateHome` instead` */
-  get home(): Paginator<FetchTimelineParams, Status[]> {
-    return this.iterateHome();
-  }
-  /** @deprecated Use `iteratePublic` instead` */
-  get public(): Paginator<FetchTimelineParams, Status[]> {
-    return this.iteratePublic();
-  }
   /** @deprecated Use `iterateHome` instead` */
   getHomeIterable = this.iterateHome.bind(this);
   /** @deprecated Use `iteratePublic` instead` */

--- a/src/repositories/trend-repository.ts
+++ b/src/repositories/trend-repository.ts
@@ -17,23 +17,15 @@ export class TrendRepository {
     readonly config: MastoConfig,
   ) {}
 
-  get statuses(): Paginator<DefaultPaginationParams, Status[]> {
-    return this.getStatuses();
-  }
-
-  get links(): Paginator<DefaultPaginationParams, Link[]> {
-    return this.getLinks();
-  }
-
   @version({ since: '3.5.0' })
-  getStatuses(
+  iterateStatuses(
     params?: DefaultPaginationParams,
   ): Paginator<DefaultPaginationParams, Status[]> {
     return new Paginator(this.http, '/api/v1/trends/statuses', params);
   }
 
   @version({ since: '3.5.0' })
-  getLinks(
+  iterateLinks(
     params?: DefaultPaginationParams,
   ): Paginator<DefaultPaginationParams, Link[]> {
     return new Paginator(this.http, '/api/v1/trends/links', params);
@@ -52,4 +44,16 @@ export class TrendRepository {
 
   /** @deprecated Use `fetchTags` */
   fetchAll = this.fetchTags.bind(this);
+  /** @deprecated Use `iterateStatuses` instead */
+  getStatuses = this.iterateStatuses.bind(this);
+  /** @deprecated Use `iterateStatuses` instead */
+  getLinks = this.iterateLinks.bind(this);
+  /** @deprecated Use `iterateStatuses` instead */
+  get statuses(): Paginator<DefaultPaginationParams, Status[]> {
+    return this.iterateStatuses();
+  }
+  /** @deprecated Use `iterateStatuses` instead */
+  get links(): Paginator<DefaultPaginationParams, Link[]> {
+    return this.iterateLinks();
+  }
 }

--- a/src/repositories/trend-repository.ts
+++ b/src/repositories/trend-repository.ts
@@ -31,6 +31,14 @@ export class TrendRepository {
     return new Paginator(this.http, '/api/v1/trends/links', params);
   }
 
+  get statuses(): Paginator<DefaultPaginationParams, Status[]> {
+    return this.iterateStatuses();
+  }
+
+  get links(): Paginator<DefaultPaginationParams, Link[]> {
+    return this.iterateLinks();
+  }
+
   /**
    * Tags that are being used more frequently within the past week.
    * @param params Parameters
@@ -48,12 +56,4 @@ export class TrendRepository {
   getStatuses = this.iterateStatuses.bind(this);
   /** @deprecated Use `iterateStatuses` instead */
   getLinks = this.iterateLinks.bind(this);
-  /** @deprecated Use `iterateStatuses` instead */
-  get statuses(): Paginator<DefaultPaginationParams, Status[]> {
-    return this.iterateStatuses();
-  }
-  /** @deprecated Use `iterateStatuses` instead */
-  get links(): Paginator<DefaultPaginationParams, Link[]> {
-    return this.iterateLinks();
-  }
 }

--- a/tests/accounts.spec.ts
+++ b/tests/accounts.spec.ts
@@ -72,9 +72,9 @@ describe('account', () => {
     expect(relationship.note).toBe(comment);
   });
 
-  it('excludes replies from getStatusesIterable', async () => {
+  it('excludes replies from iterateStatuses', async () => {
     const statuses = await client.accounts
-      .getStatusesIterable(TARGET_ID, {
+      .iterateStatuses(TARGET_ID, {
         excludeReplies: true,
       })
       .next();


### PR DESCRIPTION
Currently, the repository classes provide a method named `getXXXIterable` that returns a `Paginator` instance, but the name is unintuitive and too long.

This PR renames `getXXXIterable` to `iterateXXX` to solve this problem