### PR TITLE
Fix wrong types on fetch instance information

### DIFF
--- a/src/entities/instance.ts
+++ b/src/entities/instance.ts
@@ -16,12 +16,14 @@ export interface InstanceMediaAttachmentsConfiguration {
 }
 
 export interface InstancePollsConfiguration {
-  supportedMimeTypes: string[];
-  imageSizeLimit: number;
-  imageMatrixLimit: number;
-  videoSizeLimit: number;
-  videoFrameRateLimit: number;
-  videoMatrixLimit: number;
+  maxOptions: number;
+  maxCharactersPerOption: number;
+  minExpiration: number;
+  maxExpiration: number;
+}
+
+export interface InstanceAccountsConfiguration {
+  maxFeaturedTags: number;
 }
 
 /**
@@ -31,6 +33,7 @@ export interface InstanceConfiguration {
   statuses: InstanceStatusesConfiguration;
   mediaAttachments: InstanceMediaAttachmentsConfiguration;
   polls: InstancePollsConfiguration;
+  accounts: InstanceAccountsConfiguration;
 }
 
 /**


### PR DESCRIPTION
The typing for the poll configuration was just copy-pasted from the media attachment settings. So I fixed that, and it was missing the account configuration.

That's all for now. If we want to update to the `v2` API there are other new configuration fields available.