### PR TITLE
Additional account status options

### DIFF
--- a/src/repositories/account-repository.ts
+++ b/src/repositories/account-repository.ts
@@ -9,7 +9,7 @@ import type {
   List,
   Relationship,
   Source,
-  Status,
+  Status
 } from '../entities';
 import type { Http } from '../http';
 import { Paginator } from '../paginator';
@@ -71,6 +71,10 @@ export interface FetchAccountStatusesParams extends DefaultPaginationParams {
   readonly pinned?: boolean | null;
   /** Skip statuses that reply to other statuses */
   readonly excludeReplies?: boolean | null;
+  /** Skip statuses that are boosts of other statuses */
+  readonly excludeReblogs?: boolean | null;
+  /** Only return statuses using a specific hashtag */
+  readonly tagged?: string | null;
 }
 
 export interface FollowAccountParams {

--- a/src/repositories/account-repository.ts
+++ b/src/repositories/account-repository.ts
@@ -9,7 +9,7 @@ import type {
   List,
   Relationship,
   Source,
-  Status
+  Status,
 } from '../entities';
 import type { Http } from '../http';
 import { Paginator } from '../paginator';


### PR DESCRIPTION
Adds `excludeReblogs` and `tagged` options to `masto.accounts.iterateStatuses`. These were added to the API in 2.7.0 and 2.8.0 respectively.
