### PR TITLE
chore: add backwards-compatible type declarations

### DIFF
--- a/fetch.d.ts
+++ b/fetch.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/index';

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   "files": [
     "README.md",
     "dist",
-    "fetch",
+    "fetch.d.ts",
     "!**/__tests__",
     "!**/__mocks__"
   ],


### PR DESCRIPTION
This allows users who aren't yet on Node16 resolution to have type support when importing from `masto/fetch`.