### PR TITLE
fix: Change HTTP methods to uppercase

### DIFF
--- a/src/http/base-http.ts
+++ b/src/http/base-http.ts
@@ -38,7 +38,7 @@ export abstract class BaseHttp implements Http {
 
   get<T>(url: string, data?: Data, init: Partial<Request> = {}): Promise<T> {
     return this.request({
-      method: 'get',
+      method: 'GET',
       url,
       params: data,
       ...init,
@@ -47,7 +47,7 @@ export abstract class BaseHttp implements Http {
 
   post<T>(url: string, data?: Data, init: Partial<Request> = {}): Promise<T> {
     return this.request({
-      method: 'post',
+      method: 'POST',
       url,
       data,
       ...init,
@@ -56,7 +56,7 @@ export abstract class BaseHttp implements Http {
 
   delete<T>(url: string, data?: Data, init: Partial<Request> = {}): Promise<T> {
     return this.request({
-      method: 'delete',
+      method: 'DELETE',
       url,
       data,
       ...init,
@@ -65,7 +65,7 @@ export abstract class BaseHttp implements Http {
 
   put<T>(url: string, data?: Data, init: Partial<Request> = {}): Promise<T> {
     return this.request({
-      method: 'put',
+      method: 'PUT',
       url,
       data,
       ...init,
@@ -74,7 +74,7 @@ export abstract class BaseHttp implements Http {
 
   patch<T>(url: string, data?: Data, init: Partial<Request> = {}): Promise<T> {
     return this.request({
-      method: 'patch',
+      method: 'PATCH',
       url,
       data,
       ...init,

--- a/src/http/http.ts
+++ b/src/http/http.ts
@@ -3,7 +3,7 @@ export type Data = unknown;
 
 export type Request = {
   readonly url: string;
-  readonly method: 'get' | 'post' | 'patch' | 'delete' | 'put' | 'options';
+  readonly method: 'GET' | 'POST' | 'PATCH' | 'DELETE' | 'PUT' | 'OPTIONS';
   readonly headers?: Headers;
   readonly params?: Data;
   readonly data?: Data;

--- a/src/paginator.spec.ts
+++ b/src/paginator.spec.ts
@@ -15,7 +15,7 @@ describe('Paginator', () => {
     });
     await paginator.next();
     expect(http.request).toBeCalledWith({
-      method: 'get',
+      method: 'GET',
       url: '/v1/api/timelines',
       params: { foo: 'bar' },
     });
@@ -31,7 +31,7 @@ describe('Paginator', () => {
     await paginator.next();
     await paginator.next();
     expect(http.request).toBeCalledWith({
-      method: 'get',
+      method: 'GET',
       params: {},
       url: '/api/v1/timelines/home?max_id=109382006402042919',
     });

--- a/src/paginator.ts
+++ b/src/paginator.ts
@@ -27,7 +27,7 @@ export class Paginator<Params, Result>
     }
 
     const response: Response<Result> = await this.http.request({
-      method: 'get',
+      method: 'GET',
       // if no params specified, use link header
       url: params ? this.initialUrl : this.nextUrl,
       params: params ?? this.nextParams,


### PR DESCRIPTION
When you invoke fetch version `masto.accounts.updateCredentials` in CORS aware environment, you'll get an error because   the HTTP method `patch` mismatches with the allowed HTTP method `PATCH`.

This is because other methods including `GET` , `POST`, `DELETE`, and `PUT` are specified to be normalized to case-insensitive, so CORS check passes regardless of the case. However, PATCH is not listed are the method to normalize.

More info: https://github.com/github/fetch/issues/37