### PR TITLE
feat: add clone for Paginator

### DIFF
--- a/src/paginator.ts
+++ b/src/paginator.ts
@@ -76,4 +76,9 @@ export class Paginator<Entity, Params = never>
 
     return path;
   };
+
+  clone(): Paginator<Entity, Params> {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return new Paginator(this.http, this.nextPath!, this.nextParams);
+  }
 }


### PR DESCRIPTION
Calling `next` method will mutate the paginator, so I want to avoid this. Then cloning the paginator is necessary.