### PR TITLE
fix(paginator): parse array in url query string correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "change-case": "^4.1.2",
     "eventemitter3": "^5.0.0",
     "isomorphic-ws": "^5.0.0",
+    "query-string": "7.1.3",
     "semver": "^7.3.7",
     "ws": "^8.12.0"
   },

--- a/src/paginator.spec.ts
+++ b/src/paginator.spec.ts
@@ -106,4 +106,17 @@ describe('Paginator', () => {
       value: undefined,
     });
   });
+
+  it('parse array in url query string correctly', async () => {
+    http.request.mockReturnValue({
+      headers: new Headers({
+        link: '<https://mastodon.social/api/v1/notifications?types[]=mention>; rel="next", <https://mastodon.social/api/v1/notifications??types[]=mention>; rel="prev"',
+      }),
+    });
+    const paginator = new Paginator(http, '/v1/api/notifications', {
+      types: ['mention'],
+    });
+    await paginator.next();
+    expect((paginator as any).nextParams).toEqual({ types: ['mention'] });
+  });
 });

--- a/src/paginator.spec.ts
+++ b/src/paginator.spec.ts
@@ -110,7 +110,7 @@ describe('Paginator', () => {
   it('parse array in url query string correctly', async () => {
     http.request.mockReturnValue({
       headers: new Headers({
-        link: '<https://mastodon.social/api/v1/notifications?types[]=mention>; rel="next", <https://mastodon.social/api/v1/notifications??types[]=mention>; rel="prev"',
+        link: '<https://mastodon.social/api/v1/notifications?types[]=mention>; rel="next", <https://mastodon.social/api/v1/notifications?types[]=mention>; rel="prev"',
       }),
     });
     const paginator = new Paginator(http, '/v1/api/notifications', {

--- a/src/paginator.ts
+++ b/src/paginator.ts
@@ -1,4 +1,6 @@
 /* eslint-disable unicorn/no-thenable */
+import querystring from 'query-string';
+
 import type { Http } from './http';
 
 export class Paginator<Entity, Params = never>
@@ -8,7 +10,7 @@ export class Paginator<Entity, Params = never>
     private readonly http: Http,
     private nextPath?: string,
     private nextParams?: Params,
-  ) {}
+  ) { }
 
   async next(): Promise<IteratorResult<Entity, undefined>> {
     if (this.nextPath == undefined) {
@@ -23,9 +25,9 @@ export class Paginator<Entity, Params = never>
 
     const next = this.pluckNext(response.headers.get('link'))?.split('?');
     this.nextPath = next?.[0];
-    this.nextParams = Object.fromEntries(
-      new URLSearchParams(next?.[1]).entries(),
-    ) as Params;
+    this.nextParams = querystring.parse(next?.[1] ?? '', {
+      arrayFormat: 'bracket',
+    }) as Params;
 
     return {
       done: false,

--- a/src/paginator.ts
+++ b/src/paginator.ts
@@ -10,7 +10,7 @@ export class Paginator<Entity, Params = never>
     private readonly http: Http,
     private nextPath?: string,
     private nextParams?: Params,
-  ) { }
+  ) {}
 
   async next(): Promise<IteratorResult<Entity, undefined>> {
     if (this.nextPath == undefined) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2578,6 +2578,11 @@ decamelize@^1.1.0:
   resolved "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
   integrity sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==
 
+decode-uri-component@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
+  integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
+
 dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz"
@@ -3175,6 +3180,11 @@ fill-range@^7.0.1:
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
+
+filter-obj@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz#9b311112bc6c6127a16e016c6c5d7f19e0805c5b"
+  integrity sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==
 
 find-cache-dir@^3.3.2:
   version "3.3.2"
@@ -5823,6 +5833,16 @@ qrcode-terminal@^0.12.0:
   resolved "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz"
   integrity sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==
 
+query-string@7.1.3:
+  version "7.1.3"
+  resolved "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz#a1cf90e994abb113a325804a972d98276fe02328"
+  integrity sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==
+  dependencies:
+    decode-uri-component "^0.2.2"
+    filter-obj "^1.1.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz"
@@ -6373,6 +6393,11 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz"
   integrity sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==
 
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
 split2@^3.0.0:
   version "3.2.2"
   resolved "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz"
@@ -6427,6 +6452,11 @@ stream-events@^1.0.5:
   integrity sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==
   dependencies:
     stubs "^3.0.0"
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==
 
 string-length@^4.0.1:
   version "4.0.2"


### PR DESCRIPTION
The array in the url query string can't be parsed correctly  in `Paginator.next()` function.

![masto-bug](https://user-images.githubusercontent.com/22515951/212609620-95a40075-f5a4-4670-835e-428df23e5281.png)

Be related to Elk's issue [#1140](https://github.com/elk-zone/elk/issues/1140)