### PR TITLE
feat: Add translate API

### DIFF
--- a/src/mastodon/v1/entities/index.ts
+++ b/src/mastodon/v1/entities/index.ts
@@ -33,4 +33,5 @@ export * from './status-source';
 export * from './suggestion';
 export * from './tag';
 export * from './token';
+export * from './translation';
 export * from './web-push-subscription';

--- a/src/mastodon/v1/entities/translation.ts
+++ b/src/mastodon/v1/entities/translation.ts
@@ -1,0 +1,8 @@
+export interface Translation {
+  /** The translated text of the status. */
+  id: string;
+  /** The language of the source text, as auto-detected by the machine translation provider. */
+  detectedLanguageSource: string;
+  /** The service that provided the machine translation. */
+  provider: string;
+}

--- a/src/mastodon/v1/repositories/status-repository.ts
+++ b/src/mastodon/v1/repositories/status-repository.ts
@@ -13,6 +13,7 @@ import type {
   StatusEdit,
   StatusSource,
   StatusVisibility,
+  Translation,
 } from '../entities';
 
 export interface CreateStatusParamsBase {
@@ -87,6 +88,11 @@ export type UpdateStatusParams = CreateStatusParams & {
 export interface ReblogStatusParams {
   /** any visibility except limited or direct (i.e. public, unlisted, private). Defaults to public. Currently unused in UI. */
   readonly visibility: StatusVisibility;
+}
+
+export interface TranslateStatusParams {
+  /** String (ISO 639 language code). The status content will be translated into this language. Defaults to the user’s current locale. */
+  readonly lang?: string;
 }
 
 export class StatusRepository implements Repository<Status> {
@@ -334,5 +340,18 @@ export class StatusRepository implements Repository<Status> {
   @version({ since: '3.5.0' })
   fetchSource(id: string): Promise<StatusSource> {
     return this.http.get(`/api/v1/statuses/${id}/source`);
+  }
+
+  /**
+   * Translate the status content into some language.
+   * @param id String. The ID of the Status in the database.
+   * @param params Form data parameters
+   * @returns Translation
+   */
+  @version({ since: '4.0.0' })
+  translate(id: string, params: TranslateStatusParams): Promise<Translation> {
+    return this.http.post(`/api/v1/statuses/${id}/translate`, params, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    });
   }
 }


### PR DESCRIPTION
Resolve #856 

This PR adds `/translate` API that allows you to translate a status to another language was introduced at 4.0.0. You can use it as follows.

```ts
import { login } from "masto";

const masto = await login(...);

const statuses = await masto.v1.timelines.listPublic({ local: true }).next();
const status = statuses.value[0];
console.info(`Status: ${status.content}`);

const translation1 = await masto.v1.statuses.translate(status.id, { lang: 'ja' });
console.info(`Translation: ${translation.content}`);
```