### PR TITLE
fix: Link header parsing when order is first prev and then next link

### DIFF
--- a/src/paginator.spec.ts
+++ b/src/paginator.spec.ts
@@ -54,6 +54,22 @@ describe('Paginator', () => {
     });
   });
 
+  it('parses the next url regardless of order', async () => {
+    http.request.mockReturnValue({
+      headers: new Headers({
+        link: '<https://mastodon.social/api/v1/timelines/home?min_id=109382039876197520>; rel="prev", <https://mastodon.social/api/v1/timelines/home?max_id=109382006402042919>; rel="next"',
+      }),
+    });
+    const paginator = new Paginator(http, '/v1/api/timelines');
+    await paginator.next();
+    await paginator.next();
+    expect(http.request).toBeCalledWith({
+      requestInit: { method: 'GET' },
+      searchParams: { max_id: '109382006402042919' },
+      path: '/api/v1/timelines/home',
+    });
+  });
+
   it('returns done when next link does not exist', async () => {
     const paginator = new Paginator(http, '/v1/api/timelines');
     await paginator.next();

--- a/src/paginator.ts
+++ b/src/paginator.ts
@@ -80,7 +80,7 @@ export class Paginator<Entity, Params = never>
     }
 
     const path = link
-      .match(/<(.+?)>; rel="next"/)?.[1]
+      .match(/<([^>]+?)>; rel="next"/)?.[1]
       .replace(/^https?:\/\/[^/]+/, '');
 
     return path;


### PR DESCRIPTION
This used to rely on the link header having first the next and then the prev link.

Trying to track down why pagination in Elk with [Takahe](https://github.com/jointakahe/takahe) is broken even though it is supposed to be Mastodon API compatible. Don't think this will get it working immediately, but found this issue when trying out pagination with masto.js directly.