### PR TITLE
Add 'report' attribute to the Notification entity

### DIFF
--- a/src/mastodon/v1/entities/notification.ts
+++ b/src/mastodon/v1/entities/notification.ts
@@ -1,4 +1,5 @@
 import type { Account } from './account';
+import type { Report } from './report';
 import type { Status } from './status';
 
 export type NotificationType =
@@ -29,4 +30,7 @@ export interface Notification {
 
   /** Status that was the object of the notification, e.g. in mentions, reblogs, favourites, or polls. */
   status?: Status | null;
+
+  /** Report that was the object of the notification. Attached when type of the notification is admin.report. */
+  report?: Report | null;
 }


### PR DESCRIPTION
This was added in Mastodon 4.0.0 and allows seeing the report data for report notifications.

See: https://docs.joinmastodon.org/entities/Notification/#report

Motivated by: https://github.com/elk-zone/elk/pull/2045