### PR TITLE
Fix type error in V1::instance

### DIFF
--- a/src/mastodon/v1/entities/instance.ts
+++ b/src/mastodon/v1/entities/instance.ts
@@ -4,7 +4,7 @@ import type { Rule } from './rule';
 export interface InstanceStatusesConfiguration {
   maxCharacters: number;
   maxMediaAttachments: number;
-  charactersReservedPerUrl: string;
+  charactersReservedPerUrl: number;
 }
 
 export interface InstanceMediaAttachmentsConfiguration {


### PR DESCRIPTION
`charactersReservedPerUrl` should be number type.

API Doc: https://docs.joinmastodon.org/entities/V1_Instance/#characters_reserved_per_url