### PR TITLE
feat: Support duration parameter for account muting

### DIFF
--- a/src/mastodon/rest/v1/account-repository.ts
+++ b/src/mastodon/rest/v1/account-repository.ts
@@ -62,6 +62,8 @@ export interface UpdateCredentialsParams {
 export interface MuteAccountParams {
   /** Mute notifications in addition to statuses? Defaults to true. */
   readonly notifications?: boolean;
+  /** Duration to mute in seconds. Defaults to 0 (indefinite). */
+  readonly duration?: number;
 }
 
 export interface CreateAccountNoteParams {

--- a/tests/rest/v1/accounts.spec.ts
+++ b/tests/rest/v1/accounts.spec.ts
@@ -2,6 +2,7 @@ import assert from "node:assert";
 import crypto from "node:crypto";
 
 import { MastoHttpError } from "../../../src/adapters/errors";
+import { sleep } from "../../../src/utils";
 
 describe("account", () => {
   it("creates an account", () => {
@@ -164,6 +165,22 @@ describe("account", () => {
       expect(relationship.muting).toBe(true);
 
       relationship = await alice.rest.v1.accounts.$select(bob.id).unmute();
+      expect(relationship.muting).toBe(false);
+    });
+  });
+
+  it("mutes by ID for 1s", () => {
+    return sessions.use(2, async ([alice, bob]) => {
+      let relationship = await alice.rest.v1.accounts
+        .$select(bob.id)
+        .mute({ duration: 1 });
+      expect(relationship.muting).toBe(true);
+
+      await sleep(5000);
+
+      [relationship] = await alice.rest.v1.accounts.relationships.fetch({
+        id: [bob.id],
+      });
       expect(relationship.muting).toBe(false);
     });
   });


### PR DESCRIPTION
Hello, this PR adds a `duration` parameter support for the account mute method. The `duration` parameter was added in v3.3.0, which takes the number of seconds to mute, instead of muting the account forever.

ref. accounts API methods - Mastodon documentation - https://docs.joinmastodon.org/methods/accounts/#mute

By the way, with this parameter support, Elk could have a feature to allow users to apply shorter muting (https://github.com/elk-zone/elk/issues/2301).