### PR TITLE
Add new keywords to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,11 @@
     "url": "git+https://github.com/neet/masto.js.git"
   },
   "keywords": [
-    "mastodon"
+    "mastodon",
+    "client",
+    "activitypub",
+    "federated",
+    "fediverse"
   ],
   "bugs": {
     "url": "https://github.com/neet/masto.js/issues"


### PR DESCRIPTION
Add new items into keyword list for relevant search terms. Currently it's impossible to find the package by queries like:
* "activitypub client"
* "fediverse client"

In the same time other packages could be found. To solve this I've added the next keywords:
* client
* activitypub
* federated
* fediverse