### PR TITLE
fix: Use `Blob | string` as a type annotation for media

### DIFF
--- a/src/mastodon/rest/v1/account-repository.ts
+++ b/src/mastodon/rest/v1/account-repository.ts
@@ -42,9 +42,9 @@ export interface UpdateCredentialsParams {
   /** The account bio. */
   readonly note?: string | null;
   /** Avatar image encoded using multipart/form-data */
-  readonly avatar?: unknown;
+  readonly avatar?: Blob | string | null;
   /** Header image encoded using multipart/form-data */
-  readonly header?: unknown;
+  readonly header?: Blob | string | null;
   /** Whether manual approval of follow requests is required. */
   readonly locked?: boolean | null;
   readonly source?: Partial<

--- a/src/mastodon/rest/v1/media-attachment-repository.ts
+++ b/src/mastodon/rest/v1/media-attachment-repository.ts
@@ -3,13 +3,13 @@ import { type MediaAttachment } from "../../entities/v1";
 
 export interface CreateMediaAttachmentParams {
   /** The file to be attached, using multipart form data. */
-  readonly file: unknown;
+  readonly file: Blob | string;
   /** A plain-text description of the media, for accessibility purposes. */
   readonly description?: string | null;
   /** Two floating points (x,y), comma-delimited, ranging from -1.0 to 1.0 */
   readonly focus?: string | null;
   /** Custom thumbnail */
-  readonly thumbnail?: unknown | null;
+  readonly thumbnail?: Blob | string | null;
 }
 
 export type UpdateMediaAttachmentParams = Partial<CreateMediaAttachmentParams>;

--- a/src/mastodon/rest/v1/status-repository.ts
+++ b/src/mastodon/rest/v1/status-repository.ts
@@ -71,7 +71,7 @@ interface UpdateStatusMediaAttribute {
   /** Two floating points (x,y), comma-delimited, ranging from -1.0 to 1.0 */
   readonly focus?: string | null;
   /** Custom thumbnail */
-  readonly thumbnail?: unknown | null;
+  readonly thumbnail?: Blob | string | null;
 }
 
 export type UpdateStatusParams = CreateStatusParams & {

--- a/src/mastodon/rest/v2/media-attachment-repository.ts
+++ b/src/mastodon/rest/v2/media-attachment-repository.ts
@@ -3,13 +3,13 @@ import { type MediaAttachment } from "../../entities/v1";
 
 export interface CreateMediaAttachmentParams {
   /** The file to be attached, using multipart form data. */
-  readonly file: unknown;
+  readonly file: Blob | string;
   /** A plain-text description of the media, for accessibility purposes. */
   readonly description?: string | null;
   /** Two floating points (x,y), comma-delimited, ranging from -1.0 to 1.0 */
   readonly focus?: string | null;
   /** Custom thumbnail */
-  readonly thumbnail?: unknown | null;
+  readonly thumbnail?: Blob | string | null;
 }
 
 export interface CreateMediaAttachmentExtraParams {


### PR DESCRIPTION
Fix for https://github.com/neet/masto.js/discussions/977