### PR TITLE
fix: Fix type of hashtags to be an array in `Search` entity

### DIFF
--- a/src/mastodon/entities/v2/search.ts
+++ b/src/mastodon/entities/v2/search.ts
@@ -10,5 +10,5 @@ export interface Search {
   /** Statuses which match the given query */
   statuses: Status[];
   /** Hashtags which match the given query */
-  hashtags: Tag;
+  hashtags: Tag[];
 }


### PR DESCRIPTION
Closes #1018 