### PR TITLE
fix: Use PUT for update for Mastodon-fork compatibility

### DIFF
--- a/src/adapters/action/dispatcher-http-hook-mastodon.ts
+++ b/src/adapters/action/dispatcher-http-hook-mastodon.ts
@@ -99,7 +99,19 @@ export class HttpActionDispatcherHookMastodon
       : action.path + "/" + snakeCase(action.type);
     const encoding = inferEncoding(type, path);
     const meta: HttpMetaParams<Encoding> = { ...action.meta, encoding };
+
     return { type, path, data: action.data, meta };
+  }
+
+  dispatch(action: AnyAction): false | Promise<unknown> {
+    if (
+      action.type === "update" &&
+      action.path === "/api/v1/accounts/update_credentials"
+    ) {
+      return this.http.patch(action.path, action.data, action.meta);
+    }
+
+    return false;
   }
 
   afterDispatch(action: AnyAction, result: unknown): unknown {

--- a/src/adapters/action/dispatcher-http.ts
+++ b/src/adapters/action/dispatcher-http.ts
@@ -20,7 +20,10 @@ export class HttpActionDispatcher implements ActionDispatcher<HttpAction> {
       action = this.hook.beforeDispatch(action);
     }
 
-    let result: T | Promise<T>;
+    let result = this.hook.dispatch(action) as T | Promise<T> | false;
+    if (result !== false) {
+      return result;
+    }
 
     switch (action.type) {
       case "fetch": {
@@ -32,7 +35,7 @@ export class HttpActionDispatcher implements ActionDispatcher<HttpAction> {
         break;
       }
       case "update": {
-        result = this.http.patch(action.path, action.data, action.meta);
+        result = this.http.put(action.path, action.data, action.meta);
         break;
       }
       case "remove": {

--- a/src/adapters/http/base-http.ts
+++ b/src/adapters/http/base-http.ts
@@ -48,7 +48,6 @@ export abstract class BaseHttp implements Http {
     }).then((response) => response.data as T);
   }
 
-  /* istanbul ignore next */
   put<T>(
     path: string,
     data?: unknown,

--- a/src/interfaces/action.ts
+++ b/src/interfaces/action.ts
@@ -17,5 +17,6 @@ export interface ActionDispatcher<T extends AnyAction> {
 
 export interface ActionDispatcherHook<T extends AnyAction, U = unknown> {
   beforeDispatch(action: T): T;
+  dispatch(action: T): U | Promise<U> | false;
   afterDispatch(action: T, result: U | Promise<U>): U;
 }


### PR DESCRIPTION
Related to #1017 