### PR TITLE
feat: Support `grant_type: authorization_code` and `client_credentials`.

### DIFF
--- a/src/mastodon/oauth/token-repository.ts
+++ b/src/mastodon/oauth/token-repository.ts
@@ -1,16 +1,43 @@
 import { type HttpMetaParams } from "../../interfaces";
 import { type Token } from "../entities/v1";
 
-export interface CreateTokenParamsWithPassword {
-  readonly grantType: "password";
+/**
+ * @deprecated Use `CreateTokenParamsWithPassword` instead
+ */
+export type CreateTokenParamsWithPassword = CreateTokenWithPasswordParams;
+
+interface BaseCreateTokenParams<T extends string> {
+  /** Set equal to `authorization_code` if code is provided in order to gain user-level access. Otherwise, set equal to `client_credentials` to obtain app-level access only. */
+  readonly grantType: T;
+  /** The client ID, obtained during app registration. */
   readonly clientId: string;
+  /** The client secret, obtained during app registration. */
   readonly clientSecret: string;
-  readonly username: string;
-  readonly password: string;
+  /** Set a URI to redirect the user to. If this parameter is set to urn:ietf:wg:oauth:2.0:oob then the token will be shown instead. Must match one of the `redirect_uris` declared during app registration. */
+  readonly redirectUri: string;
+  /** List of requested OAuth scopes, separated by spaces (or by pluses, if using query parameters). If code was provided, then this must be equal to the `scope` requested from the user. Otherwise, it must be a subset of `scopes` declared during app registration. If not provided, defaults to read. */
   readonly scope?: string;
 }
 
-export type CreateTokenParams = CreateTokenParamsWithPassword;
+export interface CreateTokenWithAuthorizationCodeParams
+  extends BaseCreateTokenParams<"authorization_code"> {
+  /** A user authorization code, obtained via GET /oauth/authorize. */
+  readonly code: string;
+}
+
+export type CreateTokenWithClientCredentialsParams =
+  BaseCreateTokenParams<"client_credentials">;
+
+export interface CreateTokenWithPasswordParams
+  extends BaseCreateTokenParams<"password"> {
+  readonly password: string;
+  readonly username: string;
+}
+
+export type CreateTokenParams =
+  | CreateTokenWithClientCredentialsParams
+  | CreateTokenWithPasswordParams
+  | CreateTokenWithAuthorizationCodeParams;
 
 export interface TokenRepository {
   create(

--- a/test-utils/jest-global-setup.ts
+++ b/test-utils/jest-global-setup.ts
@@ -51,6 +51,7 @@ const readOrCreateAdminToken = async (
     username: "admin@localhost",
     password: "mastodonadmin",
     scope: "read write follow push admin:read admin:write",
+    redirectUri: "urn:ietf:wg:oauth:2.0:oob",
   });
 
   fs.writeFile(tokenFilePath, JSON.stringify(token, undefined, 2));

--- a/test-utils/pools/token-factory-docker.ts
+++ b/test-utils/pools/token-factory-docker.ts
@@ -38,6 +38,7 @@ export class TokenFactoryDocker implements TokenFactory {
       username: email,
       password,
       scope: "read write follow push admin:read admin:write",
+      redirectUri: "urn:ietf:wg:oauth:2.0:oob",
     });
 
     return token;

--- a/tests/oauth/token.spec.ts
+++ b/tests/oauth/token.spec.ts
@@ -13,6 +13,7 @@ it("issues and revokes token", async () => {
     username: "admin@localhost",
     password: "mastodonadmin",
     scope: "read",
+    redirectUri: "urn:ietf:wg:oauth:2.0:oob",
   });
 
   expect(token).toHaveProperty("accessToken");


### PR DESCRIPTION
Closes #1057 (#1055 )