### PR TITLE
chore(refactor): Use namespaces for Mastodon entities

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -53,6 +53,12 @@
       }
     },
     {
+      "files": "./src/mastodon/**/*.ts",
+      "rules": {
+        "@typescript-eslint/no-namespace": "off"
+      }
+    },
+    {
       "files": "examples/**",
       "parserOptions": {
         "project": "./examples/tsconfig.json"

--- a/src/mastodon/entities/v1/account.ts
+++ b/src/mastodon/entities/v1/account.ts
@@ -1,40 +1,6 @@
 import { type CustomEmoji } from "./custom-emoji";
 import { type Role } from "./role";
-import { type StatusVisibility } from "./status";
-
-/**
- * Represents display or publishing preferences of user's own account.
- * Returned as an additional entity when verifying and updated credentials, as an attribute of Account.
- * @see https://docs.joinmastodon.org/entities/source/
- */
-export interface AccountSource {
-  /** Profile bio. */
-  note: string;
-  /** Metadata about the account. */
-  fields: AccountField;
-
-  /** The default post privacy to be used for new statuses. */
-  privacy?: StatusVisibility | null;
-  /** Whether new statuses should be marked sensitive by default. */
-  sensitive?: boolean | null;
-  /** The default posting language for new statuses. */
-  language: string | null;
-  /** The number of pending follow requests. */
-  followRequestsCount?: number | null;
-}
-
-/**
- * Represents a profile field as a name-value pair with optional verification.
- */
-export interface AccountField {
-  /** The key of a given field's key-value pair. */
-  name: string;
-  /** The value associated with the `name` key. */
-  value: string;
-
-  /** Timestamp of when the server verified a URL value for a rel="me” link. */
-  verifiedAt?: string | null;
-}
+import { type Status } from "./status";
 
 /**
  * Represents a user of Mastodon and their associated profile.
@@ -64,7 +30,7 @@ export interface Account {
   /** Whether the account manually approves follow requests. */
   locked: boolean;
   /** Additional metadata attached to a profile as name-value pairs. */
-  fields: AccountField[];
+  fields: Account.Field[];
   /** Custom emoji entities to be used when rendering the profile. If none, an empty array will be returned. */
   emojis: CustomEmoji[];
   /** Boolean to indicate that the account performs automated actions */
@@ -97,16 +63,60 @@ export interface Account {
   memorial?: boolean | null;
 }
 
-/**
- * @see https://docs.joinmastodon.org/entities/Account/#CredentialAccount
- */
-export interface AccountCredentials extends Account {
+export namespace Account {
   /**
-   * Note the extra `source` property, which is not visible on accounts other than your own.
-   * Also note that plain-text is used within `source` and HTML is used for their
-   * corresponding properties such as `note` and `fields`.
+   * Represents display or publishing preferences of user's own account.
+   * Returned as an additional entity when verifying and updated credentials, as an attribute of Account.
+   * @see https://docs.joinmastodon.org/entities/source/
    */
-  source: AccountSource;
-  /** The role assigned to the currently authorized user. */
-  role: Role;
+  export interface Source {
+    /** Profile bio. */
+    note: string;
+    /** Metadata about the account. */
+    fields: Field;
+    /** The default post privacy to be used for new statuses. */
+    privacy?: Status.Visibility | null;
+    /** Whether new statuses should be marked sensitive by default. */
+    sensitive?: boolean | null;
+    /** The default posting language for new statuses. */
+    language: string | null;
+    /** The number of pending follow requests. */
+    followRequestsCount?: number | null;
+  }
+
+  /**
+   * Represents a profile field as a name-value pair with optional verification.
+   */
+  export interface Field {
+    /** The key of a given field's key-value pair. */
+    name: string;
+    /** The value associated with the `name` key. */
+    value: string;
+
+    /** Timestamp of when the server verified a URL value for a rel="me” link. */
+    verifiedAt?: string | null;
+  }
+
+  /**
+   * @see https://docs.joinmastodon.org/entities/Account/#CredentialAccount
+   */
+  export interface Credentials extends Account {
+    /**
+     * Note the extra `source` property, which is not visible on accounts other than your own.
+     * Also note that plain-text is used within `source` and HTML is used for their
+     * corresponding properties such as `note` and `fields`.
+     */
+    source: Source;
+    /** The role assigned to the currently authorized user. */
+    role: Role;
+  }
 }
+
+/** @deprecated Use Account.Field */
+export type AccountField = Account.Field;
+
+/** @deprecated Use Account.Source */
+export type AccountSource = Account.Source;
+
+/** @deprecated Use Account.Credentials */
+export type AccountCredentials = Account.Credentials;

--- a/src/mastodon/entities/v1/admin/cohort.ts
+++ b/src/mastodon/entities/v1/admin/cohort.ts
@@ -1,14 +1,3 @@
-export type CohortFrequency = "day" | "month";
-
-export interface CohortData {
-  /** The timestamp for the start of the bucket, at midnight. */
-  date: string;
-  /** The percentage rate of users who registered in the specified `period` and were active for the given `date` bucket. */
-  rate: number;
-  /** How many users registered in the specified `period` and were active for the given `date` bucket. */
-  value: number;
-}
-
 /**
  * Represents a retention metric.
  */
@@ -16,7 +5,26 @@ export interface Cohort {
   /** The timestamp for the start of the period, at midnight. */
   period: string;
   /** The size of the bucket for the returned data. */
-  frequency: CohortFrequency;
+  frequency: Cohort.Frequency;
   /** Retention data for users who registered during the given period. */
-  data: CohortData[];
+  data: Cohort.Data[];
 }
+
+export namespace Cohort {
+  export type Frequency = "day" | "month";
+
+  export interface Data {
+    /** The timestamp for the start of the bucket, at midnight. */
+    date: string;
+    /** The percentage rate of users who registered in the specified `period` and were active for the given `date` bucket. */
+    rate: number;
+    /** How many users registered in the specified `period` and were active for the given `date` bucket. */
+    value: number;
+  }
+}
+
+/** @deprecated Use Cohort.Frequency */
+export type CohortFrequency = Cohort.Frequency;
+
+/** @deprecated Use Cohort.Data */
+export type CohortData = Cohort.Data;

--- a/src/mastodon/entities/v1/admin/dimension.ts
+++ b/src/mastodon/entities/v1/admin/dimension.ts
@@ -1,34 +1,42 @@
-export interface DimensionData {
-  /** The unique keystring for this data item. */
-  key: string;
-  /** A human-readable key for this data item. */
-  humanKey: string;
-  /** The value for this data item. */
-  value: string;
-  /** The units associated with this data item’s value, if applicable. */
-  unit?: string | null;
-  /** A human-readable formatted value for this data item. */
-  humanValue?: string | null;
-}
-
-export type DimensionKey =
-  | "languages"
-  | "sources"
-  | "servers"
-  | "space_usage"
-  | "software_versions"
-  | "tag_servers"
-  | "tag_languages"
-  | "instance_accounts"
-  | "instance_languages";
-
 /**
  * Represents qualitative data about the server.
  * @see https://docs.joinmastodon.org/entities/Admin_Dimension/
  */
 export interface Dimension {
   /** The unique keystring for the requested dimension. */
-  key: DimensionKey;
+  key: Dimension.Key;
   /** The data available for the requested dimension. */
-  data: DimensionData[];
+  data: Dimension.Data[];
 }
+
+export namespace Dimension {
+  export interface Data {
+    /** The unique keystring for this data item. */
+    key: string;
+    /** A human-readable key for this data item. */
+    humanKey: string;
+    /** The value for this data item. */
+    value: string;
+    /** The units associated with this data item’s value, if applicable. */
+    unit?: string | null;
+    /** A human-readable formatted value for this data item. */
+    humanValue?: string | null;
+  }
+
+  export type Key =
+    | "languages"
+    | "sources"
+    | "servers"
+    | "space_usage"
+    | "software_versions"
+    | "tag_servers"
+    | "tag_languages"
+    | "instance_accounts"
+    | "instance_languages";
+}
+
+/** @deprecated Use Dimension.Key */
+export type DimensionKey = Dimension.Key;
+
+/** @deprecated Use Dimension.Data */
+export type DimensionData = Dimension.Data;

--- a/src/mastodon/entities/v1/admin/domain-block.ts
+++ b/src/mastodon/entities/v1/admin/domain-block.ts
@@ -1,5 +1,3 @@
-export type DomainBlockSeverity = "silence" | "suspend" | "noop";
-
 export interface DomainBlock {
   /** The ID of the domain block in the database. */
   id: string;
@@ -8,7 +6,7 @@ export interface DomainBlock {
   /** The create date of the domain block in the database. */
   createdAt: string;
   /** The date of the application that created this account. */
-  severity: DomainBlockSeverity;
+  severity: DomainBlock.Severity;
   /** The reject media of the domain. */
   rejectMedia: boolean;
   /** The reject report of the domain. */
@@ -20,3 +18,10 @@ export interface DomainBlock {
   /** The obfuscate of the domain block. */
   obfuscate: boolean;
 }
+
+export namespace DomainBlock {
+  export type Severity = "silence" | "suspend" | "noop";
+}
+
+/** @deprecated Use DomainBlock.Severity */
+export type DomainBlockSeverity = DomainBlock.Severity;

--- a/src/mastodon/entities/v1/admin/email-domain-block.ts
+++ b/src/mastodon/entities/v1/admin/email-domain-block.ts
@@ -1,12 +1,3 @@
-export interface EmailDomainBlockHistory {
-  /** UNIX timestamp on midnight of the given day. */
-  day: string;
-  /** The counted accounts signup attempts using that email domain within that day. */
-  accounts: string;
-  /** The counted IP signup attempts of that email domain within that day. */
-  uses: string;
-}
-
 export interface EmailDomainBlock {
   /** The ID of the email domain block in the database. */
   id: string;
@@ -15,5 +6,19 @@ export interface EmailDomainBlock {
   /** The create date of the email domain block in the database. */
   createdAt: string;
   /** The history of the email domain block in the database. */
-  history: EmailDomainBlockHistory[];
+  history: EmailDomainBlock.History[];
 }
+
+export namespace EmailDomainBlock {
+  export interface History {
+    /** UNIX timestamp on midnight of the given day. */
+    day: string;
+    /** The counted accounts signup attempts using that email domain within that day. */
+    accounts: string;
+    /** The counted IP signup attempts of that email domain within that day. */
+    uses: string;
+  }
+}
+
+/** @deprecated Use EmailDomainBlock.History */
+export type EmailDomainBlockHistory = EmailDomainBlock.History;

--- a/src/mastodon/entities/v1/admin/ip-block.ts
+++ b/src/mastodon/entities/v1/admin/ip-block.ts
@@ -1,15 +1,10 @@
-export type IpBlockSeverity =
-  | "sign_up_requires_approval"
-  | "sign_up_block"
-  | "no_access";
-
 export interface IpBlock {
   /** The ID of the domain allow in the database. */
   id: string;
   /** The IP address and prefix to block. */
   ip: string;
   /** The policy to apply to this IP range. */
-  severity: IpBlockSeverity;
+  severity: IpBlock.Severity;
   /** The reason for this IP block. */
   comment: string;
   /** The create date of the ip block. */
@@ -17,3 +12,13 @@ export interface IpBlock {
   /** The number of seconds in which this IP block will expire. */
   expiresAt: number | null;
 }
+
+export namespace IpBlock {
+  export type Severity =
+    | "sign_up_requires_approval"
+    | "sign_up_block"
+    | "no_access";
+}
+
+/** @deprecated Use IpBlock.Severity */
+export type IpBlockSeverity = IpBlock.Severity;

--- a/src/mastodon/entities/v1/admin/measure.ts
+++ b/src/mastodon/entities/v1/admin/measure.ts
@@ -1,34 +1,10 @@
-export interface MeasureData {
-  /** Midnight on the requested day in the time period. */
-  date: string;
-  /** The numeric value for the requested measure. */
-  value: string;
-}
-
-/** @see https://docs.joinmastodon.org/entities/Admin_Measure/#key */
-export type MeasureKey =
-  | "active_users"
-  | "new_users"
-  | "interactions"
-  | "opened_reports"
-  | "resolved_reports"
-  | "tag_accounts"
-  | "tag_uses"
-  | "tag_servers"
-  | "instance_accounts"
-  | "instance_media_attachments"
-  | "instance_reports"
-  | "instance_statuses"
-  | "instance_follows"
-  | "instance_followers";
-
 /**
  * Represents quantitative data about the server.
  * @see https://docs.joinmastodon.org/entities/Admin_Measure
  */
 export interface Measure {
   /** The unique keystring for the requested measure. */
-  key: MeasureKey;
+  key: Measure.Key;
   /** The units associated with this data item’s value, if applicable. */
   unit?: string | null;
   /** The numeric total associated with the requested measure. */
@@ -38,5 +14,37 @@ export interface Measure {
   /** The numeric total associated with the requested measure, in the previous period. Previous period is calculated by subtracting the start_at and end_at dates, then offsetting both start and end dates backwards by the length of the time period. */
   previousTotal?: string;
   /** The data available for the requested measure, split into daily buckets. */
-  data: MeasureData[];
+  data: Measure.Data[];
 }
+
+export namespace Measure {
+  export interface Data {
+    /** Midnight on the requested day in the time period. */
+    date: string;
+    /** The numeric value for the requested measure. */
+    value: string;
+  }
+
+  /** @see https://docs.joinmastodon.org/entities/Admin_Measure/#key */
+  export type Key =
+    | "active_users"
+    | "new_users"
+    | "interactions"
+    | "opened_reports"
+    | "resolved_reports"
+    | "tag_accounts"
+    | "tag_uses"
+    | "tag_servers"
+    | "instance_accounts"
+    | "instance_media_attachments"
+    | "instance_reports"
+    | "instance_statuses"
+    | "instance_follows"
+    | "instance_followers";
+}
+
+/** @deprecated Use Measure.Key */
+export type MeasureKey = Measure.Key;
+
+/** @deprecated Use Measure.Data */
+export type MeasureData = Measure.Data;

--- a/src/mastodon/entities/v1/admin/report.ts
+++ b/src/mastodon/entities/v1/admin/report.ts
@@ -1,5 +1,5 @@
 import { type Account } from "../account";
-import { type ReportCategory } from "../report";
+import { type Report as PublicReport } from "../report";
 import { type Rule } from "../rule";
 import { type Status } from "../status";
 
@@ -15,7 +15,7 @@ export interface Report {
   /** When an action was taken, if this report is currently resolved. */
   actionTakenAt?: string | null;
   /** The category under which the report is classified */
-  category: ReportCategory;
+  category: PublicReport.Category;
   /** An optional reason for reporting. */
   comment: string;
   /** Whether a report was forwarded to a remote instance. */

--- a/src/mastodon/entities/v1/admin/tag.ts
+++ b/src/mastodon/entities/v1/admin/tag.ts
@@ -1,9 +1,3 @@
-export interface TagHistory {
-  day: string;
-  accounts: string;
-  uses: string;
-}
-
 /**
  * @see https://docs.joinmastodon.org/entities/Tag/#admin
  */
@@ -12,7 +6,7 @@ export interface Tag {
   id: string;
   name: string;
   url: string;
-  history: TagHistory[];
+  history: Tag.History[];
   /** Whether the hashtag has been approved to trend. */
   trendable: boolean;
   /** Whether the hashtag has not been disabled from auto-linking. */
@@ -20,3 +14,14 @@ export interface Tag {
   /** Whether the hashtag has not been reviewed yet to approve or deny its trending. */
   requiresReview: boolean;
 }
+
+export namespace Tag {
+  export interface History {
+    day: string;
+    accounts: string;
+    uses: string;
+  }
+}
+
+/** @deprecated Use Tag.History */
+export type TagHistory = Tag.History;

--- a/src/mastodon/entities/v1/announcement.ts
+++ b/src/mastodon/entities/v1/announcement.ts
@@ -2,18 +2,6 @@ import { type CustomEmoji } from "./custom-emoji";
 import { type Reaction } from "./reaction";
 import { type Tag } from "./tag";
 
-export interface AnnouncementAccount {
-  id: string;
-  username: string;
-  url: string;
-  acct: string;
-}
-
-export interface AnnouncementStatus {
-  id: string;
-  url: string;
-}
-
 export interface Announcement {
   id: string;
   content: string;
@@ -22,9 +10,29 @@ export interface Announcement {
   allDay: boolean;
   publishedAt: string;
   updatedAt: string;
-  mentions: AnnouncementAccount[];
-  statuses: AnnouncementStatus[];
+  mentions: Announcement.Account[];
+  statuses: Announcement.Status[];
   tags: Tag[];
   emojis: CustomEmoji[];
   reactions: Reaction[];
 }
+
+export namespace Announcement {
+  export interface Account {
+    id: string;
+    username: string;
+    url: string;
+    acct: string;
+  }
+
+  export interface Status {
+    id: string;
+    url: string;
+  }
+}
+
+/** @deprecated Use Announcement.Account */
+export type AnnouncementAccount = Announcement.Account;
+
+/** @deprecated Use Announcement.Status */
+export type AnnouncementStatus = Announcement.Status;

--- a/src/mastodon/entities/v1/filter.ts
+++ b/src/mastodon/entities/v1/filter.ts
@@ -1,10 +1,3 @@
-export type FilterContext =
-  | "home"
-  | "notifications"
-  | "public"
-  | "thread"
-  | "account";
-
 /**
  * Represents a user-defined filter for determining which statuses should not be shown to the user.
  * @see https://docs.joinmastodon.org/entities/filter/
@@ -15,7 +8,7 @@ export interface Filter {
   /** The text to be filtered. */
   phrase: string;
   /** The contexts in which the filter should be applied. */
-  context: FilterContext[];
+  context: Filter.Context[];
   /** When the filter should no longer be applied */
   expiresAt?: string | null;
   /** Should matching entities in home and notifications be dropped by the server? */
@@ -23,3 +16,15 @@ export interface Filter {
   /** Should the filter consider word boundaries? */
   wholeWord: boolean;
 }
+
+export namespace Filter {
+  export type Context =
+    | "home"
+    | "notifications"
+    | "public"
+    | "thread"
+    | "account";
+}
+
+/** @deprecated Use Filter.Context instead */
+export type FilterContext = Filter.Context;

--- a/src/mastodon/entities/v1/instance.ts
+++ b/src/mastodon/entities/v1/instance.ts
@@ -1,42 +1,6 @@
 import { type Account } from "./account";
 import { type Rule } from "./rule";
 
-export interface InstanceStatusesConfiguration {
-  maxCharacters: number;
-  maxMediaAttachments: number;
-  charactersReservedPerUrl: number;
-}
-
-export interface InstanceMediaAttachmentsConfiguration {
-  supportedMimeTypes: string[];
-  imageSizeLimit: number;
-  imageMatrixLimit: number;
-  videoSizeLimit: number;
-  videoFrameRateLimit: number;
-  videoMatrixLimit: number;
-}
-
-export interface InstancePollsConfiguration {
-  maxOptions: number;
-  maxCharactersPerOption: number;
-  minExpiration: number;
-  maxExpiration: number;
-}
-
-export interface InstanceAccountsConfiguration {
-  maxFeaturedTags: number;
-}
-
-/**
- * @see https://github.com/mastodon/mastodon/pull/16485
- */
-export interface InstanceConfiguration {
-  statuses: InstanceStatusesConfiguration;
-  mediaAttachments: InstanceMediaAttachmentsConfiguration;
-  polls: InstancePollsConfiguration;
-  accounts: InstanceAccountsConfiguration;
-}
-
 /**
  * Represents the software instance of Mastodon running on this domain.
  * @see https://docs.joinmastodon.org/entities/instance/
@@ -61,13 +25,13 @@ export interface Instance {
   /** Whether registrations require moderator approval. */
   approvalRequired: boolean;
   /** URLs of interest for clients apps. */
-  urls: InstanceURLs;
+  urls: Instance.Urls;
   /** Statistics about how much information the instance contains. */
-  stats: InstanceStats;
+  stats: Instance.Stats;
   /** Whether invitation in enabled */
   invitesEnabled: boolean;
   /** List various values like file size limits and supported mime types */
-  configuration: InstanceConfiguration;
+  configuration: Instance.Configuration;
 
   /** Banner image for the website. */
   thumbnail?: string | null;
@@ -77,16 +41,78 @@ export interface Instance {
   rules?: Rule[] | null;
 }
 
-export interface InstanceURLs {
-  /** WebSockets address for push streaming. String (URL). */
-  streamingApi: string;
+export namespace Instance {
+  /**
+   * @see https://github.com/mastodon/mastodon/pull/16485
+   */
+  export interface Configuration {
+    statuses: Configuration.Statuses;
+    mediaAttachments: Configuration.MediaAttachments;
+    polls: Configuration.Polls;
+    accounts: Configuration.Accounts;
+  }
+
+  export namespace Configuration {
+    export interface Statuses {
+      maxCharacters: number;
+      maxMediaAttachments: number;
+      charactersReservedPerUrl: number;
+    }
+
+    export interface MediaAttachments {
+      supportedMimeTypes: string[];
+      imageSizeLimit: number;
+      imageMatrixLimit: number;
+      videoSizeLimit: number;
+      videoFrameRateLimit: number;
+      videoMatrixLimit: number;
+    }
+
+    export interface Polls {
+      maxOptions: number;
+      maxCharactersPerOption: number;
+      minExpiration: number;
+      maxExpiration: number;
+    }
+
+    export interface Accounts {
+      maxFeaturedTags: number;
+    }
+  }
+
+  export interface Urls {
+    /** WebSockets address for push streaming. String (URL). */
+    streamingApi: string;
+  }
+
+  export interface Stats {
+    /** Users registered on this instance. Number. */
+    userCount: number;
+    /** Statuses authored by users on instance. Number. */
+    statusCount: number;
+    /** Domains federated with this instance. Number. */
+    domainCount: number;
+  }
 }
 
-export interface InstanceStats {
-  /** Users registered on this instance. Number. */
-  userCount: number;
-  /** Statuses authored by users on instance. Number. */
-  statusCount: number;
-  /** Domains federated with this instance. Number. */
-  domainCount: number;
-}
+/** @deprecated Use Instance.Configuration */
+export type InstanceConfiguration = Instance.Configuration;
+
+/** @deprecated Use Instance.Configuration.Statuses */
+export type InstanceStatusesConfiguration = Instance.Configuration.Statuses;
+
+/** @deprecated Use Instance.Configuration.MediaAttachments */
+export type InstanceMediaAttachmentsConfiguration =
+  Instance.Configuration.MediaAttachments;
+
+/** @deprecated Use Instance.Configuration.Polls */
+export type InstancePollsConfiguration = Instance.Configuration.Polls;
+
+/** @deprecated Use Instance.Configuration.Accounts */
+export type InstanceAccountsConfiguration = Instance.Configuration.Accounts;
+
+/** @deprecated Use Instance.Stats */
+export type InstanceStats = Instance.Stats;
+
+/** @deprecated Use Instance.Urls */
+export type InstanceURLs = Instance.Urls;

--- a/src/mastodon/entities/v1/list.ts
+++ b/src/mastodon/entities/v1/list.ts
@@ -1,5 +1,3 @@
-export type ListRepliesPolicy = "followed" | "list" | "none";
-
 /**
  * Represents a list of some users that the authenticated user follows.
  * @see https://docs.joinmastodon.org/entities/list/
@@ -18,7 +16,14 @@ export interface List {
    *
    * `none` = Show replies to no one
    */
-  repliesPolicy: ListRepliesPolicy;
+  repliesPolicy: List.RepliesPolicy;
   /** https://github.com/mastodon/mastodon/pull/22048/files */
   exclusive: boolean;
 }
+
+export namespace List {
+  export type RepliesPolicy = "followed" | "list" | "none";
+}
+
+/** @deprecated Use List.RepliesPolicy */
+export type ListRepliesPolicy = List.RepliesPolicy;

--- a/src/mastodon/entities/v1/marker.ts
+++ b/src/mastodon/entities/v1/marker.ts
@@ -1,16 +1,24 @@
-export interface MarkerItem {
-  /** The ID of the most recently viewed entity. */
-  lastReadId: string;
-  /** The timestamp of when the marker was set. */
-  updatedAt: string;
-  /** Used for locking to prevent write conflicts. */
-  version: number;
-}
-
-export type MarkerTimeline = "home" | "notifications";
-
 /**
  * Represents the last read position within a user's timelines.
  * @see https://docs.joinmastodon.org/entities/marker/
  */
-export type Marker = { [key in MarkerTimeline]: MarkerItem };
+export type Marker = { [key in Marker.Timeline]: Marker.Item };
+
+export namespace Marker {
+  export interface Item {
+    /** The ID of the most recently viewed entity. */
+    lastReadId: string;
+    /** The timestamp of when the marker was set. */
+    updatedAt: string;
+    /** Used for locking to prevent write conflicts. */
+    version: number;
+  }
+
+  export type Timeline = "home" | "notifications";
+}
+
+/** @deprecated Use Marker.Item */
+export type MarkerItem = Marker.Item;
+
+/** @deprecated Use Marker.Timeline */
+export type MarkerTimeline = Marker.Timeline;

--- a/src/mastodon/entities/v1/media-attachment.ts
+++ b/src/mastodon/entities/v1/media-attachment.ts
@@ -1,44 +1,3 @@
-export type MediaAttachmentType =
-  | "image"
-  | "video"
-  | "gifv"
-  | "audio"
-  | "unknown";
-
-export interface MediaAttachmentMetaImage {
-  width: number;
-  height: number;
-  size: string;
-  aspect: number;
-}
-
-export interface MediaAttachmentMetaVideo {
-  width: number;
-  height: number;
-  frameRate: string;
-  duration: number;
-  bitrate: number;
-  aspect: number;
-}
-
-export interface MediaAttachmentMetaFocus {
-  x: number;
-  y: number;
-}
-
-export interface MediaAttachmentMetaColors {
-  background: string;
-  foreground: string;
-  accent: string;
-}
-
-export interface MediaAttachmentMeta {
-  small?: MediaAttachmentMetaImage | MediaAttachmentMetaVideo | null;
-  original?: MediaAttachmentMetaImage | MediaAttachmentMetaVideo | null;
-  focus?: MediaAttachmentMetaFocus | null;
-  colors?: MediaAttachmentMetaColors | null;
-}
-
 /**
  * Represents a file or media MediaAttachment that can be added to a status.
  * @see https://docs.joinmastodon.org/entities/MediaAttachment/
@@ -47,7 +6,7 @@ export interface MediaAttachment {
   /** The ID of the MediaAttachment in the database. */
   id: string;
   /** The type of the MediaAttachment. */
-  type: MediaAttachmentType;
+  type: MediaAttachment.Type;
   /** The location of the original full-size MediaAttachment. */
   url?: string | null;
   /** The location of a scaled-down preview of the MediaAttachment. */
@@ -59,7 +18,7 @@ export interface MediaAttachment {
   /** A shorter URL for the MediaAttachment. */
   textUrl?: string | null;
   /** Metadata returned by Paperclip. */
-  meta?: MediaAttachmentMeta | null;
+  meta?: MediaAttachment.Meta | null;
   /**
    * Alternate text that describes what is in the media MediaAttachment,
    * to be used for the visually impaired or when media MediaAttachments do not load.
@@ -71,3 +30,61 @@ export interface MediaAttachment {
    */
   blurhash?: string | null;
 }
+
+export namespace MediaAttachment {
+  export type Type = "image" | "video" | "gifv" | "audio" | "unknown";
+
+  export interface Meta {
+    small?: Meta.Image | Meta.Video | null;
+    original?: Meta.Image | Meta.Video | null;
+    focus?: Meta.Focus | null;
+    colors?: Meta.Colors | null;
+  }
+
+  export namespace Meta {
+    export interface Image {
+      width: number;
+      height: number;
+      size: string;
+      aspect: number;
+    }
+
+    export interface Video {
+      width: number;
+      height: number;
+      frameRate: string;
+      duration: number;
+      bitrate: number;
+      aspect: number;
+    }
+
+    export interface Focus {
+      x: number;
+      y: number;
+    }
+
+    export interface Colors {
+      background: string;
+      foreground: string;
+      accent: string;
+    }
+  }
+}
+
+/** @deprecated Use MediaAttachment.Type instead */
+export type MediaAttachmentType = MediaAttachment.Type;
+
+/**  @deprecated Use MediaAttachment.Meta instead */
+export type MediaAttachmentMeta = MediaAttachment.Meta;
+
+/**  @deprecated Use MediaAttachment.Meta.Image instead */
+export type MediaAttachmentMetaImage = MediaAttachment.Meta.Image;
+
+/**  @deprecated Use MediaAttachment.Meta.Video instead */
+export type MediaAttachmentMetaVideo = MediaAttachment.Meta.Video;
+
+/**  @deprecated Use MediaAttachment.Meta.Focus instead */
+export type MediaAttachmentMetaFocus = MediaAttachment.Meta.Focus;
+
+/**  @deprecated Use MediaAttachment.Meta.Colors instead */
+export type MediaAttachmentMetaColors = MediaAttachment.Meta.Colors;

--- a/src/mastodon/entities/v1/notification.ts
+++ b/src/mastodon/entities/v1/notification.ts
@@ -34,68 +34,104 @@ type BaseNotificationWithReport<T> = BaseNotification<T> & {
   report: Report;
 };
 
-/**
- * Someone mentioned you in their status
- */
-export type MentionNotification = BaseNotificationWithStatus<"mention">;
+export namespace Notification {
+  /**
+   * Someone mentioned you in their status
+   */
+  export type Mention = BaseNotificationWithStatus<"mention">;
 
-/**
- * Someone you enabled notifications for has posted a status
- */
-export type StatusNotification = BaseNotificationWithStatus<"status">;
+  /**
+   * Someone you enabled notifications for has posted a status
+   */
+  export type Status = BaseNotificationWithStatus<"status">;
 
-/**
- * Someone boosted one of your statuses
- */
-export type ReblogNotification = BaseNotificationWithStatus<"reblog">;
+  /**
+   * Someone boosted one of your statuses
+   */
+  export type Reblog = BaseNotificationWithStatus<"reblog">;
 
-/**
- * Someone followed you
- */
-export type FollowNotification = BaseNotificationPlain<"follow">;
+  /**
+   * Someone followed you
+   */
+  export type Follow = BaseNotificationPlain<"follow">;
 
-/**
- * Someone requested to follow you
- */
-export type FollowRequestNotification = BaseNotificationPlain<"follow_request">;
+  /**
+   * Someone requested to follow you
+   */
+  export type FollowRequest = BaseNotificationPlain<"follow_request">;
 
-/**
- * Someone favourited one of your statuses
- */
-export type FavouriteNotification = BaseNotificationWithStatus<"favourite">;
+  /**
+   * Someone favourited one of your statuses
+   */
+  export type Favourite = BaseNotificationWithStatus<"favourite">;
 
-/**
- * A poll you have voted in or created has ended
- */
-export type PollNotification = BaseNotificationWithStatus<"poll">;
+  /**
+   * A poll you have voted in or created has ended
+   */
+  export type Poll = BaseNotificationWithStatus<"poll">;
 
-/**
- * A status you interacted with has been edited
- */
-export type UpdateNotification = BaseNotificationWithStatus<"update">;
+  /**
+   * A status you interacted with has been edited
+   */
+  export type Update = BaseNotificationWithStatus<"update">;
 
-/**
- * Someone signed up (optionally sent to admins)
- */
-export type AdminSignUpNotification = BaseNotificationPlain<"admin.sign_up">;
+  export namespace Admin {
+    /**
+     * Someone signed up (optionally sent to admins)
+     */
+    export type SignUp = BaseNotificationPlain<"admin.sign_up">;
 
-export type AdminReportNotification =
-  BaseNotificationWithReport<"admin.report">;
+    export type Report = BaseNotificationWithReport<"admin.report">;
+  }
+
+  export type Type = Notification["type"];
+}
 
 /**
  * Represents a notification of an event relevant to the user.
  * @see https://docs.joinmastodon.org/entities/notification
  */
 export type Notification =
-  | MentionNotification
-  | StatusNotification
-  | ReblogNotification
-  | FollowNotification
-  | FollowRequestNotification
-  | FavouriteNotification
-  | PollNotification
-  | UpdateNotification
-  | AdminSignUpNotification
-  | AdminReportNotification;
+  | Notification.Mention
+  | Notification.Status
+  | Notification.Reblog
+  | Notification.Follow
+  | Notification.FollowRequest
+  | Notification.Favourite
+  | Notification.Poll
+  | Notification.Update
+  | Notification.Admin.SignUp
+  | Notification.Admin.Report;
 
-export type NotificationType = Notification["type"];
+/** @deprecated Use Notification.Type */
+export type NotificationType = Notification.Type;
+
+/** @deprecated Use Notification.Mention */
+export type MentionNotification = Notification.Mention;
+
+/** @deprecated Use Notification.Status */
+export type StatusNotification = Notification.Status;
+
+/** @deprecated Use Notification.Reblog */
+export type ReblogNotification = Notification.Reblog;
+
+/** @deprecated Use Notification.Follow */
+export type FollowNotification = Notification.Follow;
+
+/** @deprecated Use Notification.FollowRequest */
+export type FollowRequestNotification = Notification.FollowRequest;
+
+/** @deprecated Use Notification.Favourite */
+export type FavouriteNotification = Notification.Favourite;
+
+/** @deprecated Use Notification.Poll */
+export type PollNotification = Notification.Poll;
+
+/** @deprecated Use Notification.Update */
+export type UpdateNotification = Notification.Update;
+
+/** @deprecated Use Notification.Admin.SignUp */
+export type AdminSignUpNotification = Notification.Admin.SignUp;
+
+/** @deprecated Use Notification.Admin.Report */
+export type AdminReportNotification = Notification.Admin.Report;

--- a/src/mastodon/entities/v1/poll.ts
+++ b/src/mastodon/entities/v1/poll.ts
@@ -1,14 +1,5 @@
 import { type CustomEmoji } from "./custom-emoji";
 
-export interface PollOption {
-  /** The text value of the poll option. String. */
-  title: string;
-  /** The number of received votes for this option. Number, or null if results are not published yet. */
-  votesCount?: number;
-  /** Custom emoji to be used for rendering poll options. */
-  emojis: CustomEmoji[];
-}
-
 /**
  * Represents a poll attached to a status.
  * @see https://docs.joinmastodon.org/entities/poll/
@@ -34,5 +25,19 @@ export interface Poll {
    */
   ownVotes?: number[] | null;
   /** Possible answers for the poll. */
-  options: PollOption[];
+  options: Poll.Option[];
 }
+
+export namespace Poll {
+  export interface Option {
+    /** The text value of the poll option. String. */
+    title: string;
+    /** The number of received votes for this option. Number, or null if results are not published yet. */
+    votesCount?: number;
+    /** Custom emoji to be used for rendering poll options. */
+    emojis: CustomEmoji[];
+  }
+}
+
+/** @deprecated Use Poll.Option */
+export type PollOption = Poll.Option;

--- a/src/mastodon/entities/v1/preference.ts
+++ b/src/mastodon/entities/v1/preference.ts
@@ -1,6 +1,4 @@
-import { type StatusVisibility } from "./status";
-
-export type PreferenceReadingExpandMedia = "show_all" | "hide_all" | "default";
+import { type Status } from "./status";
 
 /**
  * Represents a user's preferences.
@@ -8,15 +6,22 @@ export type PreferenceReadingExpandMedia = "show_all" | "hide_all" | "default";
  */
 export interface Preference {
   /** Default visibility for new posts. Equivalent to Source#privacy. */
-  "posting:default:visibility": StatusVisibility;
+  "posting:default:visibility": Status.Visibility;
   /** Default sensitivity flag for new posts. Equivalent to Source#sensitive. */
   "posting:default:sensitive": boolean;
   /** Default language for new posts. Equivalent to Source#language */
   "posting:default:language": string;
   /** Whether media attachments should be automatically displayed or blurred/hidden. */
-  "reading:expand:media": PreferenceReadingExpandMedia;
+  "reading:expand:media": Preference.ReadingExpandMedia;
   /** Whether CWs should be expanded by default. */
   "reading:expand:spoilers": boolean;
   /** Whether GIFs should be automatically played */
   "reading:autoplay:gifs": boolean;
 }
+
+export namespace Preference {
+  export type ReadingExpandMedia = "show_all" | "hide_all" | "default";
+}
+
+/** @deprecated Use Preference.ReadingExpandMedia */
+export type PreferenceReadingExpandMedia = Preference.ReadingExpandMedia;

--- a/src/mastodon/entities/v1/preview-card.ts
+++ b/src/mastodon/entities/v1/preview-card.ts
@@ -1,7 +1,5 @@
 import { type TagHistory } from "./tag";
 
-export type PreviewCardType = "link" | "photo" | "video" | "rich";
-
 /**
  * Represents a rich preview card that is generated using OpenGraph tags from a URL.
  * @see https://docs.joinmastodon.org/entities/PreviewCard
@@ -14,7 +12,7 @@ export interface PreviewCard {
   /** Description of preview. */
   description: string;
   /** The type of the preview card. */
-  type: PreviewCardType;
+  type: PreviewCard.Type;
   /** Blurhash */
   blurhash: string;
 
@@ -37,6 +35,13 @@ export interface PreviewCard {
   /** Used for photo embeds, instead of custom `html`. */
   embedUrl: string;
 }
+
+export namespace PreviewCard {
+  export type Type = "link" | "photo" | "video" | "rich";
+}
+
+/** @deprecated Use PreviewCard.Type */
+export type PreviewCardType = PreviewCard.Type;
 
 export interface TrendLink extends PreviewCard {
   history: TagHistory[];

--- a/src/mastodon/entities/v1/report.ts
+++ b/src/mastodon/entities/v1/report.ts
@@ -1,7 +1,5 @@
 import { type Account } from "./account";
 
-export type ReportCategory = "spam" | "violation" | "legal" | "other";
-
 /**
  * Reports filed against users and/or statuses, to be taken action on by moderators.
  * @see https://docs.joinmastodon.org/entities/Report/
@@ -22,7 +20,7 @@ export interface Report {
    *
    * `other` = Some other reason
    */
-  category: ReportCategory;
+  category: Report.Category;
   /** The reason for the report. */
   comment: string;
   /** Whether the report was forwarded to a remote domain */
@@ -36,3 +34,10 @@ export interface Report {
   /** The account that was reported. */
   targetAccount: Account;
 }
+
+export namespace Report {
+  export type Category = "spam" | "violation" | "legal" | "other";
+}
+
+/** @deprecated Use Report.Category */
+export type ReportCategory = Report.Category;

--- a/src/mastodon/entities/v1/scheduled-status.ts
+++ b/src/mastodon/entities/v1/scheduled-status.ts
@@ -1,19 +1,6 @@
 import { type MediaAttachment } from "./media-attachment";
 import { type Status } from "./status";
 
-export interface StatusParams
-  extends Pick<
-    Status,
-    "id" | "inReplyToId" | "sensitive" | "spoilerText" | "visibility"
-  > {
-  /** Content of the status */
-  text: string;
-  /** IDs of media attachments */
-  mediaIds?: string[] | null;
-  /** ID of the application */
-  applicationId: string;
-}
-
 /**
  * Represents a status that will be published at a future scheduled date.
  * @see https://docs.joinmastodon.org/entities/scheduledstatus/
@@ -24,7 +11,25 @@ export interface ScheduledStatus {
   /** ID of the status in the database. */
   scheduledAt: string;
   /** Parameters of the status */
-  params: StatusParams;
+  params: ScheduledStatus.Params;
   /** Media attachments */
   mediaAttachments: MediaAttachment[];
 }
+
+export namespace ScheduledStatus {
+  export interface Params
+    extends Pick<
+      Status,
+      "id" | "inReplyToId" | "sensitive" | "spoilerText" | "visibility"
+    > {
+    /** Content of the status */
+    text: string;
+    /** IDs of media attachments */
+    mediaIds?: string[] | null;
+    /** ID of the application */
+    applicationId: string;
+  }
+}
+
+/** @deprecated Use ScheduledStatus.Params */
+export type StatusParams = ScheduledStatus.Params;

--- a/src/mastodon/entities/v1/status.ts
+++ b/src/mastodon/entities/v1/status.ts
@@ -8,26 +8,6 @@ import { type PreviewCard } from "./preview-card";
 import { type Tag } from "./tag";
 
 /**
- * Represents a mention of a user within the content of a status.
- * @see https://docs.joinmastodon.org/entities/mention/
- */
-export interface StatusMention {
-  /** The account id of the mentioned user. */
-  id: string;
-  /** The username of the mentioned user. */
-  username: string;
-  /** The location of the mentioned user's profile. */
-  url: string;
-  /**
-   * The WebFinger acct: URI of the mentioned user.
-   * Equivalent to username for local users, or `username@domain` for remote users.
-   */
-  acct: string;
-}
-
-export type StatusVisibility = "public" | "unlisted" | "private" | "direct";
-
-/**
  * Represents a status posted by an account.
  * @see https://docs.joinmastodon.org/entities/status/
  */
@@ -45,7 +25,7 @@ export interface Status {
   /** HTML-encoded status content. */
   content: string;
   /** Visibility of this status. */
-  visibility: StatusVisibility;
+  visibility: Status.Visibility;
   /** Is this status marked as sensitive content? */
   sensitive: boolean;
   /** Subject or summary line, below which status content is collapsed until expanded. */
@@ -56,7 +36,7 @@ export interface Status {
   application: Application;
 
   /** Mentions of users within the status content. */
-  mentions: StatusMention[];
+  mentions: Status.Mention[];
   /** Hashtags used within the status content. */
   tags: Tag[];
   /** Custom emoji to be used when rendering status content. */
@@ -103,3 +83,31 @@ export interface Status {
   /** Have you pinned this status? Only appears if the status is pin-able. */
   pinned?: boolean | null;
 }
+
+export namespace Status {
+  /**
+   * Represents a mention of a user within the content of a status.
+   * @see https://docs.joinmastodon.org/entities/mention/
+   */
+  export interface Mention {
+    /** The account id of the mentioned user. */
+    id: string;
+    /** The username of the mentioned user. */
+    username: string;
+    /** The location of the mentioned user's profile. */
+    url: string;
+    /**
+     * The WebFinger acct: URI of the mentioned user.
+     * Equivalent to username for local users, or `username@domain` for remote users.
+     */
+    acct: string;
+  }
+
+  export type Visibility = "public" | "unlisted" | "private" | "direct";
+}
+
+/** @deprecated Use Status.Visibility */
+export type StatusVisibility = Status.Visibility;
+
+/** @deprecated Use Status.Mention */
+export type StatusMention = Status.Mention;

--- a/src/mastodon/entities/v1/suggestion.ts
+++ b/src/mastodon/entities/v1/suggestion.ts
@@ -1,7 +1,5 @@
 import { type Account } from "./account";
 
-export type SuggestionSource = "staff" | "past_interactions" | "global";
-
 /**
  * Represents a suggested account to follow and an associated reason for the suggestion.
  * @see https://docs.joinmastodon.org/entities/Suggestion/
@@ -13,10 +11,17 @@ export interface Suggestion {
    * `past_interactions` = You have interacted with this account previously
    * `global` = This account has many reblogs, favourites, and active local followers within the last 30 days
    */
-  source: SuggestionSource;
+  source: Suggestion.Source;
 
   /**
    * The account being recommended to follow.
    */
   account: Account;
 }
+
+export namespace Suggestion {
+  export type Source = "staff" | "past_interactions" | "global";
+}
+
+/** @deprecated Use Suggestion.Source */
+export type SuggestionSource = Suggestion.Source;

--- a/src/mastodon/entities/v1/tag.ts
+++ b/src/mastodon/entities/v1/tag.ts
@@ -1,16 +1,4 @@
 /**
- * Represents daily usage history of a hashtag.
- */
-export interface TagHistory {
-  /** UNIX timestamp on midnight of the given day. */
-  day: string;
-  /** the counted usage of the tag within that day. */
-  uses: string;
-  /** the total of accounts using the tag within that day. */
-  accounts: string;
-}
-
-/**
  * Represents a hashtag used within the content of a status.
  * @see https://docs.joinmastodon.org/entities/tag/
  */
@@ -21,7 +9,24 @@ export interface Tag {
   url: string;
 
   /** Usage statistics for given days. */
-  history?: TagHistory[] | null;
+  history?: Tag.History[] | null;
   /** Whether the current token’s authorized user is following this tag. */
   following?: boolean | null;
 }
+
+export namespace Tag {
+  /**
+   * Represents daily usage history of a hashtag.
+   */
+  export interface History {
+    /** UNIX timestamp on midnight of the given day. */
+    day: string;
+    /** the counted usage of the tag within that day. */
+    uses: string;
+    /** the total of accounts using the tag within that day. */
+    accounts: string;
+  }
+}
+
+/** @deprecated Use Tag.History */
+export type TagHistory = Tag.History;

--- a/src/mastodon/entities/v1/web-push-subscription.ts
+++ b/src/mastodon/entities/v1/web-push-subscription.ts
@@ -1,9 +1,3 @@
-export type WebPushSubscriptionPolicy =
-  | "all"
-  | "followed"
-  | "follower"
-  | "none";
-
 /**
  * Represents a subscription to the push streaming server.
  * @see https://docs.joinmastodon.org/entities/WebPushSubscription/
@@ -16,30 +10,40 @@ export interface WebPushSubscription {
   /** The streaming server's VAPID key. */
   serverKey: string;
   /** Which alerts should be delivered to the `endpoint`. */
-  alerts: WebPushSubscriptionAlerts;
+  alerts: WebPushSubscription.Alerts;
   /* Which type of notification should be included  */
-  policy: WebPushSubscriptionPolicy;
+  policy: WebPushSubscription.Policy;
 }
 
-export interface WebPushSubscriptionAlerts {
-  /** Receive a push notification when someone has followed you? Boolean. */
-  follow: boolean;
-  /** Receive a push notification when a status you created has been favourited by someone else? Boolean. */
-  favourite: boolean;
-  /** Receive a push notification when someone else has mentioned you in a status? Boolean. */
-  reblog: boolean;
-  /** Receive a push notification when a status you created has been boosted by someone else? Boolean. */
-  mention: boolean;
-  /** Receive a push notification when a poll you voted in or created has ended? Boolean. */
-  poll: boolean;
-  /** Receive new subscribed account notifications? Defaults to false. */
-  status: boolean;
-  /** Receive status edited notifications? Defaults to false. */
-  update: boolean;
-  admin: {
-    /** Receive new user signup notifications? Defaults to false. Must have a role with the appropriate permissions. */
-    signUp: boolean;
-    /** Receive new report notifications? Defaults to false. Must have a role with the appropriate permissions. */
-    report: boolean;
-  };
+export namespace WebPushSubscription {
+  export interface Alerts {
+    /** Receive a push notification when someone has followed you? Boolean. */
+    follow: boolean;
+    /** Receive a push notification when a status you created has been favourited by someone else? Boolean. */
+    favourite: boolean;
+    /** Receive a push notification when someone else has mentioned you in a status? Boolean. */
+    reblog: boolean;
+    /** Receive a push notification when a status you created has been boosted by someone else? Boolean. */
+    mention: boolean;
+    /** Receive a push notification when a poll you voted in or created has ended? Boolean. */
+    poll: boolean;
+    /** Receive new subscribed account notifications? Defaults to false. */
+    status: boolean;
+    /** Receive status edited notifications? Defaults to false. */
+    update: boolean;
+    admin: {
+      /** Receive new user signup notifications? Defaults to false. Must have a role with the appropriate permissions. */
+      signUp: boolean;
+      /** Receive new report notifications? Defaults to false. Must have a role with the appropriate permissions. */
+      report: boolean;
+    };
+  }
+
+  export type Policy = "all" | "followed" | "follower" | "none";
 }
+
+/** @deprecated Use WebPushSubscription */
+export type WebPushSubscriptionAlerts = WebPushSubscription.Alerts;
+
+/** @deprecated Use WebPushSubscription.Policy */
+export type WebPushSubscriptionPolicy = WebPushSubscription.Policy;

--- a/src/mastodon/entities/v2/filter.ts
+++ b/src/mastodon/entities/v2/filter.ts
@@ -1,15 +1,6 @@
 import { type FilterKeyword } from "../v1/filter-keyword";
 import { type FilterStatus } from "../v1/filter-status";
 
-export type FilterContext =
-  | "home"
-  | "notifications"
-  | "public"
-  | "thread"
-  | "account";
-
-export type FilterAction = "warn" | "hide";
-
 /**
  * Represents a user-defined filter for determining which statuses should not be shown to the user.
  * @see https://docs.joinmastodon.org/entities/filter/
@@ -20,7 +11,7 @@ export interface Filter {
   /** A title given by the user to name the filter. */
   title: string;
   /** The contexts in which the filter should be applied. */
-  context: FilterContext[];
+  context: Filter.Context[];
   /** When the filter should no longer be applied */
   expiresAt?: string | null;
   /**
@@ -30,9 +21,26 @@ export interface Filter {
    *
    * `hide` = do not show this status if it is received
    */
-  filterAction: FilterAction;
+  filterAction: Filter.Action;
   /** The keywords grouped under this filter. */
   keywords: FilterKeyword[];
   /** The statuses grouped under this filter. */
   statuses: FilterStatus[];
 }
+
+export namespace Filter {
+  export type Context =
+    | "home"
+    | "notifications"
+    | "public"
+    | "thread"
+    | "account";
+
+  export type Action = "warn" | "hide";
+}
+
+/** @deprecated Use Filter.Context */
+export type FilterContext = Filter.Context;
+
+/** @deprecated Use Filter.Action */
+export type FilterAction = Filter.Action;

--- a/src/mastodon/entities/v2/instance.ts
+++ b/src/mastodon/entities/v2/instance.ts
@@ -1,114 +1,5 @@
 import { type Account, type Rule } from "../v1";
 
-export interface InstanceUsageUsers {
-  /** The number of active users in the past 4 weeks. */
-  activeMonth: number;
-}
-
-export interface InstanceUsage {
-  /** Usage data related to users on this instance. */
-  users: InstanceUsageUsers;
-}
-
-export interface InstanceThumbnailVersions {
-  /** The URL for the thumbnail image at 1x resolution. */
-  "@1x": string;
-  /** The URL for the thumbnail image at 2x resolution. */
-  "@2x": string;
-}
-
-export interface InstanceThumbnail {
-  /** The URL for the thumbnail image. */
-  url: string;
-  /** A hash computed by [the BlurHash algorithm](https://github.com/woltapp/blurhash), for generating colorful preview thumbnails when media has not been downloaded yet. */
-  blurhash: string;
-  /** Links to scaled resolution images, for high DPI screens. */
-  versions: InstanceThumbnailVersions;
-}
-
-export interface InstanceUrls {
-  /** The WebSockets URL for connecting to the streaming API. */
-  streaming: string;
-  /** Instance status URL */
-  status?: string;
-}
-
-export interface InstanceAccountsConfiguration {
-  /** The maximum number of featured tags allowed for each account. */
-  maxFeaturedTags: number;
-}
-
-export interface InstanceStatusesConfiguration {
-  /** The maximum number of allowed characters per status. */
-  maxCharacters: number;
-  /** The maximum number of media attachments that can be added to a status. */
-  maxMediaAttachments: number;
-  /** Each URL in a status will be assumed to be exactly this many characters. */
-  charactersReservedPerUrl: number;
-}
-
-export interface InstanceMediaAttachmentsConfiguration {
-  /** Contains MIME types that can be uploaded. */
-  supportedMimeTypes: string[];
-  /** The maximum size of any uploaded image, in bytes. */
-  imageSizeLimit: number;
-  /** The maximum number of pixels (width times height) for image uploads. */
-  imageMatrixLimit: number;
-  /** The maximum size of any uploaded video, in bytes. */
-  videoSizeLimit: number;
-  /** The maximum frame rate for any uploaded video. */
-  videoFrameRateLimit: number;
-  /** The maximum number of pixels (width times height) for video uploads. */
-  videoMatrixLimit: number;
-}
-
-export interface InstancePollsConfiguration {
-  /** Each poll is allowed to have up to this many options. */
-  maxOptions: number;
-  /** Each poll option is allowed to have this many characters. */
-  maxCharactersPerOption: number;
-  /** The shortest allowed poll duration, in seconds. */
-  minExpiration: number;
-  /** The longest allowed poll duration, in seconds. */
-  maxExpiration: number;
-}
-
-export interface InstanceTranslationConfiguration {
-  /** Whether the Translations API is available on this instance. */
-  enabled: boolean;
-}
-
-export interface InstanceConfiguration {
-  /** URLs of interest for clients apps. */
-  urls: InstanceUrls;
-  /** Limits related to accounts. */
-  accounts: InstanceAccountsConfiguration;
-  /** Limits related to authoring statuses. */
-  statuses: InstanceStatusesConfiguration;
-  /** Hints for which attachments will be accepted. */
-  mediaAttachments: InstanceMediaAttachmentsConfiguration;
-  /** Limits related to polls. */
-  polls: InstancePollsConfiguration;
-  /** Hints related to translation. */
-  translation: InstanceTranslationConfiguration;
-}
-
-export interface InstanceRegistrations {
-  /** Whether registrations are enabled. */
-  enabled: boolean;
-  /** Whether registrations require moderator approval. */
-  approvalRequired: boolean;
-  /** A custom message to be shown when registrations are closed. */
-  message?: string | null;
-}
-
-export interface InstanceContact {
-  /** An email address that can be messaged regarding inquiries or issues. */
-  email: string;
-  /** An account that can be contacted natively over the network regarding inquiries or issues. */
-  account: Account;
-}
-
 /**
  * Represents the software instance of Mastodon running on this domain.
  * @see https://docs.joinmastodon.org/entities/Instance/
@@ -125,17 +16,175 @@ export interface Instance {
   /** A short, plain-text description defined by the admin. */
   description: string;
   /** Usage data for this instance. */
-  usage: InstanceUsage;
+  usage: Instance.Usage;
   /** An image used to represent this instance */
-  thumbnail: InstanceThumbnail;
+  thumbnail: Instance.Thumbnail;
   /** Primary languages of the website and its staff. */
   languages: string[];
   /** Configured values and limits for this website. */
-  configuration: InstanceConfiguration;
+  configuration: Instance.Configuration;
   /** Information about registering for this website. */
-  registrations: InstanceRegistrations;
+  registrations: Instance.Registrations;
   /** Hints related to contacting a representative of the website. */
-  contact: InstanceContact;
+  contact: Instance.Contact;
   /** An itemized list of rules for this website. */
   rules: Rule[];
 }
+
+export namespace Instance {
+  export interface Usage {
+    /** Usage data related to users on this instance. */
+    users: Usage.Users;
+  }
+
+  export namespace Usage {
+    export interface Users {
+      /** The number of active users in the past 4 weeks. */
+      activeMonth: number;
+    }
+  }
+
+  export interface Thumbnail {
+    /** The URL for the thumbnail image. */
+    url: string;
+    /** A hash computed by [the BlurHash algorithm](https://github.com/woltapp/blurhash), for generating colorful preview thumbnails when media has not been downloaded yet. */
+    blurhash: string;
+    /** Links to scaled resolution images, for high DPI screens. */
+    versions: Thumbnail.Versions;
+  }
+
+  export namespace Thumbnail {
+    export interface Versions {
+      /** The URL for the thumbnail image at 1x resolution. */
+      "@1x": string;
+      /** The URL for the thumbnail image at 2x resolution. */
+      "@2x": string;
+    }
+  }
+
+  export interface Configuration {
+    /** URLs of interest for clients apps. */
+    urls: Configuration.Urls;
+    /** Limits related to accounts. */
+    accounts: Configuration.Accounts;
+    /** Limits related to authoring statuses. */
+    statuses: Configuration.Statuses;
+    /** Hints for which attachments will be accepted. */
+    mediaAttachments: Configuration.MediaAttachments;
+    /** Limits related to polls. */
+    polls: Configuration.Polls;
+    /** Hints related to translation. */
+    translation: Configuration.Translation;
+  }
+
+  export namespace Configuration {
+    export interface Urls {
+      /** The WebSockets URL for connecting to the streaming API. */
+      streaming: string;
+      /** Instance status URL */
+      status?: string;
+    }
+
+    export interface Accounts {
+      /** The maximum number of featured tags allowed for each account. */
+      maxFeaturedTags: number;
+    }
+
+    export interface Statuses {
+      /** The maximum number of allowed characters per status. */
+      maxCharacters: number;
+      /** The maximum number of media attachments that can be added to a status. */
+      maxMediaAttachments: number;
+      /** Each URL in a status will be assumed to be exactly this many characters. */
+      charactersReservedPerUrl: number;
+    }
+
+    export interface MediaAttachments {
+      /** Contains MIME types that can be uploaded. */
+      supportedMimeTypes: string[];
+      /** The maximum size of any uploaded image, in bytes. */
+      imageSizeLimit: number;
+      /** The maximum number of pixels (width times height) for image uploads. */
+      imageMatrixLimit: number;
+      /** The maximum size of any uploaded video, in bytes. */
+      videoSizeLimit: number;
+      /** The maximum frame rate for any uploaded video. */
+      videoFrameRateLimit: number;
+      /** The maximum number of pixels (width times height) for video uploads. */
+      videoMatrixLimit: number;
+    }
+
+    export interface Polls {
+      /** Each poll is allowed to have up to this many options. */
+      maxOptions: number;
+      /** Each poll option is allowed to have this many characters. */
+      maxCharactersPerOption: number;
+      /** The shortest allowed poll duration, in seconds. */
+      minExpiration: number;
+      /** The longest allowed poll duration, in seconds. */
+      maxExpiration: number;
+    }
+
+    export interface Translation {
+      /** Whether the Translations API is available on this instance. */
+      enabled: boolean;
+    }
+  }
+
+  export interface Registrations {
+    /** Whether registrations are enabled. */
+    enabled: boolean;
+    /** Whether registrations require moderator approval. */
+    approvalRequired: boolean;
+    /** A custom message to be shown when registrations are closed. */
+    message?: string | null;
+  }
+
+  export interface Contact {
+    /** An email address that can be messaged regarding inquiries or issues. */
+    email: string;
+    /** An account that can be contacted natively over the network regarding inquiries or issues. */
+    account: Account;
+  }
+}
+
+/** @deprecated Use Instance.Usage */
+export type InstanceUsage = Instance.Usage;
+
+/** @deprecated Use Instance.Usage.Users */
+export type InstanceUsageUsers = Instance.Usage.Users;
+
+/** @deprecated Use Instance.Usage.Users */
+export type InstanceConfiguration = Instance.Configuration;
+
+/** @deprecated Use Instance.Configuration.Urls */
+export type InstanceUrls = Instance.Configuration.Urls;
+
+/** @deprecated Use Instance.Configuration.Accounts */
+export type InstanceAccountsConfiguration = Instance.Configuration.Accounts;
+
+/** @deprecated Use Instance.Configuration.Statuses */
+export type InstanceStatusesConfiguration = Instance.Configuration.Statuses;
+
+/** @deprecated Use Instance.Configuration.MediaAttachments */
+export type InstanceMediaAttachmentsConfiguration =
+  Instance.Configuration.MediaAttachments;
+
+/** @deprecated Use Instance.Configuration.Polls */
+export type InstancePollsConfiguration = Instance.Configuration.Polls;
+
+/** @deprecated Use Instance.Configuration.Translation */
+export type InstanceTranslationConfiguration =
+  Instance.Configuration.Translation;
+
+/** @deprecated Use Instance.Contact */
+export type InstanceContact = Instance.Contact;
+
+/** @deprecated Use Instance.Configuration */
+export type InstanceThumbnail = Instance.Thumbnail;
+
+/** @deprecated Use Instance.Thumbnail.Versions */
+export type InstanceThumbnailVersions = Instance.Thumbnail.Versions;
+
+/** @deprecated Use Instance.Configuration */
+export type InstanceRegistrations = Instance.Registrations;


### PR DESCRIPTION
Currently, we are offering type definitions for response types that are not associated to any REST API resource that are defined in docs.joinmastodon.org, such as `AccountField` or `NotificationType`. 

However, this implementation has several problems:

1. Since it is not a officially defined terminology of the REST API, it is likely to cause a conflict or breaking change once Mastodon started to offer a REST API resource that has the same name.
2. For types that consists of multiple words (such as `AdminReportNotification`), it is quite ambiguous to determine which naming convention it follows.

To resolve this, I'm changing these types to use `namespace`, allowing us to define non-resource types locally within REST resources.

You may think that TypeScript `namespace` is deprecated, but it is actually not as you can see in https://github.com/microsoft/TypeScript/issues/30994#issuecomment-491998238. You can even find some new packages that adopts `namespace` for defining scoped types including [`openai@^4.0.0`](https://npm.im/openai)