### PR TITLE
fix: Change `timeout: undefined` to fall back to Fetch API default timeout

### DIFF
--- a/src/adapters/config/http-config.spec.ts
+++ b/src/adapters/config/http-config.spec.ts
@@ -76,6 +76,26 @@ describe("Config", () => {
     expect(request.signal.aborted).toBe(true);
   });
 
+  it("falls back to default timeout if timeout = undefined (#1097)", () => {
+    jest.spyOn(AbortSignal, "timeout");
+
+    const config = new HttpConfigImpl(
+      {
+        url: "https://mastodon.social",
+        accessToken: "token",
+      },
+      new SerializerNativeImpl(),
+    );
+
+    const requestInit = config.mergeRequestInitWithDefaults();
+    const request = new Request("https://example.com", requestInit);
+
+    expect(request.signal.aborted).toBe(false);
+    expect(AbortSignal.timeout).not.toHaveBeenCalled();
+
+    jest.restoreAllMocks();
+  });
+
   it("resolves HTTP path", () => {
     const config = new HttpConfigImpl(
       {


### PR DESCRIPTION
This pull request changes the behaviour for `timeout: undefined` to fall back to the default timeout milliseconds of Fetch API instead of using `300 * 1000 ms`.

I don't regard this as a breaking change, as the default timeout of the Fetch API depends on the runtime.

Partially closes #1097 