### PR TITLE
feat: Support new `accounts` field in `PreviewCard` of status introduced by Mastodon 4.3.0

### DIFF
--- a/src/mastodon/entities/v1/preview-card.ts
+++ b/src/mastodon/entities/v1/preview-card.ts
@@ -1,5 +1,5 @@
+import { type Account } from "./account";
 import { type TagHistory } from "./tag";
-import { Account } from "./account";
 
 export type PreviewCardType = "link" | "photo" | "video" | "rich";
 

--- a/src/mastodon/entities/v1/preview-card.ts
+++ b/src/mastodon/entities/v1/preview-card.ts
@@ -1,6 +1,20 @@
 import { type TagHistory } from "./tag";
+import { Account } from "./account";
 
 export type PreviewCardType = "link" | "photo" | "video" | "rich";
+
+/**
+ * Represents an author in a rich preview card.
+ * @see https://docs.joinmastodon.org/entities/PreviewCardAuthor/
+ */
+export interface PreviewCardAuthor {
+  /** The original resource author’s name. Replaces the deprecated author_name attribute of the preview card. */
+  name: string;
+  /** A link to the author of the original resource. Replaces the deprecated author_url attribute of the preview card. */
+  url: string;
+  /** The fediverse account of the author. */
+  account: Account | null;
+}
 
 /**
  * Represents a rich preview card that is generated using OpenGraph tags from a URL.
@@ -17,10 +31,17 @@ export interface PreviewCard {
   type: PreviewCardType;
   /** Blurhash */
   blurhash: string;
-
-  /** The author of the original resource. */
+  /** Fediverse account of the authors of the original resource. */
+  authors: PreviewCardAuthor[];
+  /**
+   * The author of the original resource.
+   * @deprecated Use `authors` instead
+   */
   authorName?: string | null;
-  /** A link to the author of the original resource. */
+  /**
+   * A link to the author of the original resource.
+   * @deprecated Use `authors` instead
+   */
   authorUrl?: string | null;
   /** The provider of the original resource. */
   providerName?: string | null;


### PR DESCRIPTION
Hello, I'm currently implementing a new author information feature in Elk (https://github.com/elk-zone/elk/issues/2995) but I noticed that masto.js doesn't have new fields for that.

This PR adds new fields `accounts` and deprecates two fields `account_name` and `account_url` following the updated documentation.

Here's the Mastodon documentation page for the new `authors` field: https://docs.joinmastodon.org/entities/PreviewCard/#authors

