### PR TITLE
fix: Use Authorization header for sending access_token to WebSocket API

### DIFF
--- a/src/adapters/clients.ts
+++ b/src/adapters/clients.ts
@@ -80,7 +80,10 @@ export function createStreamingAPIClient(
     {
       constructorParameters: [
         config.resolvePath("/api/v1/streaming"),
-        config.getProtocols(),
+        [],
+        {
+          headers: config.getHeaders(),
+        },
       ],
       implementation: props.implementation,
       maxAttempts: config.getMaxAttempts(),

--- a/src/adapters/config/web-socket-config.spec.ts
+++ b/src/adapters/config/web-socket-config.spec.ts
@@ -31,7 +31,7 @@ describe("WebSocketConfigImpl", () => {
     );
   });
 
-  it("creates websocket protocol with token when supported", () => {
+  it("creates websocket header with token when supported", () => {
     const config = new WebSocketConfigImpl(
       {
         streamingApiUrl: "wss://mastodon.social",
@@ -40,10 +40,10 @@ describe("WebSocketConfigImpl", () => {
       new SerializerNativeImpl(),
     );
 
-    expect(config.getProtocols()).toEqual(["token"]);
+    expect(config.getHeaders()).toEqual({ Authorization: "token" });
   });
 
-  it("creates websocket protocol without token when not supported", () => {
+  it("creates websocket header without token when not supported", () => {
     const config = new WebSocketConfigImpl(
       {
         streamingApiUrl: "wss://mastodon.social",
@@ -53,7 +53,7 @@ describe("WebSocketConfigImpl", () => {
       new SerializerNativeImpl(),
     );
 
-    expect(config.getProtocols()).toEqual([]);
+    expect(config.getHeaders()).toEqual({});
   });
 
   it("gets max attempts with retry true", () => {

--- a/src/adapters/config/web-socket-config.ts
+++ b/src/adapters/config/web-socket-config.ts
@@ -59,15 +59,17 @@ export class WebSocketConfigImpl implements WebSocketConfig {
     private readonly serializer: Serializer,
   ) {}
 
-  getProtocols(protocols: readonly string[] = []): string[] {
+  getHeaders(): Record<string, string> {
     if (
       this.props.useInsecureAccessToken ||
       this.props.accessToken == undefined
     ) {
-      return [...protocols];
+      return {};
     }
 
-    return [this.props.accessToken, ...protocols];
+    return {
+      Authorization: this.props.accessToken,
+    };
   }
 
   resolvePath(path: string, params: Record<string, unknown> = {}): URL {

--- a/src/interfaces/config/web-socket-config.ts
+++ b/src/interfaces/config/web-socket-config.ts
@@ -1,5 +1,5 @@
 export interface WebSocketConfig {
   getMaxAttempts(): number;
-  getProtocols(protocols?: readonly string[]): string[];
+  getHeaders(): Record<string, string>;
   resolvePath(path: string, params?: Record<string, unknown>): URL;
 }


### PR DESCRIPTION
Closes #1248 