### PR TITLE
fix: update type information related to relationship severance

### DIFF
--- a/src/mastodon/entities/v1/notification.ts
+++ b/src/mastodon/entities/v1/notification.ts
@@ -91,7 +91,7 @@ export type AdminReportNotification =
  */
 export type SeveredRelationshipsNotification =
   BaseNotificationPlain<"severed_relationships"> & {
-    relationshipSeveranceEvent: RelationshipSeveranceEvent;
+    event: RelationshipSeveranceEvent;
   };
 
 /**

--- a/src/mastodon/entities/v1/relationship-severance-event.ts
+++ b/src/mastodon/entities/v1/relationship-severance-event.ts
@@ -8,10 +8,12 @@ export interface RelationshipSeveranceEvent {
   type: RelationshipSeveranceEventType;
   /** Whether the list of severed relationships is unavailable because the underlying issue has been purged. */
   purged: boolean;
+  /** Number of followers that were removed as result of the event. */
+  followersCount: number;
+  /** Number of accounts the user stopped following as result of the event. */
+  followingCount: number;
   /** Name of the target of the moderation/block event. This is either a domain name or a user handle, depending on the event type. */
   targetName: string;
-  /** Number of follow relationships (in either direction) that were severed. */
-  relationshipsCount?: number | null;
   /** When the event took place. */
   createdAt: string;
 }


### PR DESCRIPTION
Hello, this PR fixes two type definitions, found when implementing the support for relationship severance notification on Elk.

1. When the notification type is `severed_relationships` the correct prop name was actually `event`.

- Mastodon documentation: https://docs.joinmastodon.org/entities/Notification/#relationship_severance_event
- Source code: https://github.com/mastodon/mastodon/blob/main/app/serializers/rest/notification_serializer.rb#L12
  - It seems that `key: :event` specifies the JSON key name for `relationship_severance_event` value here.
    - ref. rails-api/active_model_serializers - https://github.com/rails-api/active_model_serializers/blob/v0.10.6/docs/general/serializers.md#attribute

2. Properties of `RelationshipSeveranceEvent`

The initial `relationships_count` was split into two props later by this commit: https://github.com/mastodon/mastodon/commit/dfa43707eb88276b8268e49c7853d226006bf140 

- Mastodon documentation:: https://docs.joinmastodon.org/entities/RelationshipSeveranceEvent/