### PR TITLE
fix: Revert "fix: Use Authorization header for sending access_token to WebSocket API"

### DIFF
--- a/src/adapters/clients.ts
+++ b/src/adapters/clients.ts
@@ -83,10 +83,7 @@ export function createStreamingAPIClient(
     {
       constructorParameters: [
         config.resolvePath("/api/v1/streaming"),
-        [],
-        {
-          headers: config.getHeaders(),
-        },
+        config.getProtocols(),
       ],
       implementation: props.implementation,
       maxAttempts: config.getMaxAttempts(),

--- a/src/adapters/config/web-socket-config.spec.ts
+++ b/src/adapters/config/web-socket-config.spec.ts
@@ -31,7 +31,7 @@ describe("WebSocketConfigImpl", () => {
     );
   });
 
-  it("creates websocket header with token when supported", () => {
+  it("creates websocket protocol with token when supported", () => {
     const config = new WebSocketConfigImpl(
       {
         streamingApiUrl: "wss://mastodon.social",
@@ -40,10 +40,10 @@ describe("WebSocketConfigImpl", () => {
       new SerializerNativeImpl(),
     );
 
-    expect(config.getHeaders()).toEqual({ Authorization: "Bearer token" });
+    expect(config.getProtocols()).toEqual(["token"]);
   });
 
-  it("creates websocket header without token when not supported", () => {
+  it("creates websocket protocol without token when not supported", () => {
     const config = new WebSocketConfigImpl(
       {
         streamingApiUrl: "wss://mastodon.social",
@@ -53,7 +53,7 @@ describe("WebSocketConfigImpl", () => {
       new SerializerNativeImpl(),
     );
 
-    expect(config.getHeaders()).toEqual({});
+    expect(config.getProtocols()).toEqual([]);
   });
 
   it("gets max attempts with retry true", () => {

--- a/src/adapters/config/web-socket-config.ts
+++ b/src/adapters/config/web-socket-config.ts
@@ -62,17 +62,15 @@ export class WebSocketConfigImpl implements WebSocketConfig {
     private readonly serializer: Serializer,
   ) {}
 
-  getHeaders(): Record<string, string> {
+  getProtocols(protocols: readonly string[] = []): string[] {
     if (
       this.props.useInsecureAccessToken ||
       this.props.accessToken == undefined
     ) {
-      return {};
+      return [...protocols];
     }
 
-    return {
-      Authorization: `Bearer ${this.props.accessToken}`,
-    };
+    return [this.props.accessToken, ...protocols];
   }
 
   resolvePath(path: string, params: Record<string, unknown> = {}): URL {

--- a/src/interfaces/config/web-socket-config.ts
+++ b/src/interfaces/config/web-socket-config.ts
@@ -1,5 +1,5 @@
 export interface WebSocketConfig {
   getMaxAttempts(): number;
-  getHeaders(): Record<string, string>;
+  getProtocols(protocols?: readonly string[]): string[];
   resolvePath(path: string, params?: Record<string, unknown>): URL;
 }


### PR DESCRIPTION
Revert #1255 as custom header is not supported in web browsers