### PR TITLE
fix: Client.user type

### DIFF
--- a/src/mastodon/streaming/client.ts
+++ b/src/mastodon/streaming/client.ts
@@ -68,7 +68,7 @@ export interface Client extends Disposable {
   hashtag: HashtagResource;
   list: ListResource;
   direct: DirectResource;
-  user: UserNotificationResource;
+  user: UserResource;
 
   close(): void;
 


### PR DESCRIPTION
Hi! I'm working on an [upgrade for Elk](https://github.com/elk-zone/elk/pull/3429) when I noticed [Client.user has a type error](https://github.com/elk-zone/elk/actions/runs/19583192765/job/56085908028?pr=3429), and I think it should be `UserResource` -- please let me know if it should be something else. Thanks! 🙏🏼 