### PR TITLE
feat: add three new quote states introduced by Mastodon v4.5.0

### DIFF
--- a/src/mastodon/entities/v1/quote.ts
+++ b/src/mastodon/entities/v1/quote.ts
@@ -7,6 +7,9 @@ export interface QuoteStateRegistry {
   revoked: never;
   deleted: never;
   unauthorized: never;
+  blocked_account: never;
+  blocked_domain: never;
+  muted_account: never;
 }
 
 export type QuoteState = keyof QuoteStateRegistry;


### PR DESCRIPTION
There are three new quote states: `blocked_account`, `blocked_domain`, and `muted_account`.

ref. Quote - Mastodon documentation - https://docs.joinmastodon.org/entities/Quote/

> `blocked_account` = The quote has been approved, but should not be displayed because the user has blocked the account being quoted. quoted_status is non-null.
> `blocked_domain` = The quote has been approved, but should not be displayed because the user has blocked the domain of the account being quoted. quoted_status is non-null.
> `muted_account` = The quote has been approved, but should not be displayed because the user has muted the the account being quoted. quoted_status is non-null.
> Version history:
> 4.5.0 - added blocked_account, blocked_domain and muted_account