### PR TITLE
feat: support new attributes of status - `quotesCount` and `quoteApproval` introduced by Mastodon v4.5.0

### DIFF
--- a/src/mastodon/entities/v1/quote-approval.ts
+++ b/src/mastodon/entities/v1/quote-approval.ts
@@ -1,0 +1,44 @@
+export interface QuoteApprovalPolicyRegistry {
+  public: never;
+  followers: never;
+  following: never;
+  unsupported_policy: never;
+}
+
+export type QuoteApprovalPolicy = keyof QuoteApprovalPolicyRegistry;
+
+export interface QuoteApprovalCurrentUserPolicyRegistry {
+  automatic: never;
+  manual: never;
+  denied: never;
+  unknown: never;
+}
+
+export type QuoteApprovalCurrentUserPolicy =
+  keyof QuoteApprovalCurrentUserPolicyRegistry;
+
+/**
+ * Represents a summary of a status' quote approval policy and how it applies to the requesting user.
+ * @see https://docs.joinmastodon.org/entities/QuoteApproval
+ */
+export interface QuoteApproval {
+  /**
+   * Describes who is expected to be able to quote that status and have the quote automatically authorized.
+   * An empty list means that nobody is expected to be able to quote this post. Other values may be added in the future,
+   * so unknown values should be treated as `unsupported_policy`.
+   * @see https://docs.joinmastodon.org/entities/QuoteApproval/#automatic
+   */
+  automatic: QuoteApprovalPolicy[];
+  /**
+   * Describes who is expected to have their quotes of this status be manually reviewed by the author before being accepted.
+   * An empty list means that nobody is expected to be able to quote this post. Other values may be added in the future,
+   * so unknown values should be treated as `unsupported_policy`.
+   * @see https://docs.joinmastodon.org/entities/QuoteApproval/#manual
+   */
+  manual: QuoteApprovalPolicy[];
+  /**
+   * Describes how this status’ quote policy applies to the current user.
+   * @see https://docs.joinmastodon.org/entities/QuoteApproval/#current_user
+   */
+  currentUser: QuoteApprovalCurrentUserPolicy;
+}

--- a/src/mastodon/entities/v1/status.ts
+++ b/src/mastodon/entities/v1/status.ts
@@ -6,6 +6,7 @@ import { type MediaAttachment } from "./media-attachment.js";
 import { type Poll } from "./poll.js";
 import { type PreviewCard } from "./preview-card.js";
 import { type Quote } from "./quote.js";
+import { type QuoteApproval } from "./quote-approval.js";
 import { type ShallowQuote } from "./shallow-quote.js";
 import { type Tag } from "./tag.js";
 
@@ -81,6 +82,13 @@ export interface Status {
   repliesCount: number;
   /** Information about the status being quoted, if any */
   quote?: Quote | ShallowQuote | null;
+  /** How many replies this status has received. */
+  quotesCount: number;
+  /**
+   * Summary of the post quote’s approval policy and how it applies to the user making the request,
+   * that is, whether the user can be expected to be allowed to quote that post.
+   **/
+  quoteApproval: QuoteApproval;
 
   /** A link to the status's HTML representation. */
   url?: string | null;


### PR DESCRIPTION
This adds two additional Quote-related attirbutes to the `Status` object.

ref. 
- Status - Mastodon documentation - https://docs.joinmastodon.org/entities/Status/
- QuoteApproval - Mastodon documentation - https://docs.joinmastodon.org/entities/QuoteApproval/