### PR TITLE
feat: support quotes of status API endpoint

### DIFF
--- a/src/mastodon/rest/v1/statuses.ts
+++ b/src/mastodon/rest/v1/statuses.ts
@@ -151,6 +151,15 @@ export interface Statuses$SelectFavouritedByResource {
   list: Method<Paginator<Account[]>>;
 }
 
+export interface Statuses$SelectQuotesResource {
+  /**
+   * View quotes of a status.
+   * @return Array of Status
+   * @see https://docs.joinmastodon.org/methods/statuses/#quotes
+   */
+  list: Method<Paginator<Status[]>>;
+}
+
 export interface Statuses$SelectHistoryResource {
   /**
    * Get all known versions of a status, including the initial and current states.
@@ -174,6 +183,7 @@ export interface Statuses$SelectResource {
   card: Statuses$SelectCardResource;
   rebloggedBy: Statuses$SelectRebloggedByResource;
   favouritedBy: Statuses$SelectFavouritedByResource;
+  quotes: Statuses$SelectQuotesResource;
   history: Statuses$SelectHistoryResource;
   source: Statuses$SelectSourceResource;
 


### PR DESCRIPTION
This adds support for new `GET /api/v1/statuses/:id/quotes` endpoints.

ref. statuses API methods - Mastodon documentation - https://docs.joinmastodon.org/methods/statuses/#quotes

I tried adding a new test case but e2e test couldn't be passed as it requires Mastodon v4.5.0 container.