### PR TITLE
feat: update `AccountSource` type

### DIFF
--- a/src/mastodon/entities/v1/account.ts
+++ b/src/mastodon/entities/v1/account.ts
@@ -1,3 +1,4 @@
+import { type QuoteApprovalPolicy } from "../../rest/v1/statuses.js";
 import { type CustomEmoji } from "./custom-emoji.js";
 import { type Role } from "./role.js";
 import { type StatusVisibility } from "./status.js";
@@ -8,11 +9,12 @@ import { type StatusVisibility } from "./status.js";
  * @see https://docs.joinmastodon.org/entities/source/
  */
 export interface AccountSource {
-  /** Profile bio. */
+  /** Domains of websites allowed to credit the account. */
+  attributionDomains: string[];
+  /** Profile bio, in plain text instead of HTML. */
   note: string;
   /** Metadata about the account. */
   fields: AccountField[];
-
   /** The default post privacy to be used for new statuses. */
   privacy?: StatusVisibility | null;
   /** Whether new statuses should be marked sensitive by default. */
@@ -21,6 +23,16 @@ export interface AccountSource {
   language: string | null;
   /** The number of pending follow requests. */
   followRequestsCount?: number | null;
+  /** Whether the user hides the contents of their follows and followers collections. */
+  hideCollections?: boolean | null;
+  /**  Whether the account has opted into discovery features such as the profile directory. */
+  discoverable?: boolean | null;
+  /** Whether public posts should be searchable to anyone. */
+  indexable: boolean;
+  /** The default quote policy to be used for new statuses. */
+  quotePolicy: QuoteApprovalPolicy;
+  /** The complete role assigned to the currently authorized user, including permissions and highlighted status. */
+  role: Role;
 }
 
 /**
@@ -31,7 +43,6 @@ export interface AccountField {
   name: string;
   /** The value associated with the `name` key. */
   value: string;
-
   /** Timestamp of when the server verified a URL value for a rel="me” link. */
   verifiedAt?: string | null;
 }

--- a/src/mastodon/rest/v1/statuses.ts
+++ b/src/mastodon/rest/v1/statuses.ts
@@ -22,8 +22,11 @@ export interface FetchStatusesParams {
 }
 
 export interface QuoteApprovalPolicyRegistry {
+  /** Anyone is allowed to quote this status and will have their quote automatically accepted, unless they are blocked. */
   public: never;
+  /** Only followers and the author are allowed to quote this status, and will have their quote automatically accepted. */
   followers: never;
+  /** Only the author is allowed to quote the status. */
   nobody: never;
 }
 
@@ -34,10 +37,7 @@ export interface CreateStatusParamsBase {
   readonly inReplyToId?: string | null;
   /** ID of the status being quoted, if any. Will raise an error if the status does not exist, the author does not have access to it, or quoting is denied by Mastodon’s understanding of the attached quote policy. All posts except Private Mentions (direct visibility) are quotable by their author. Quoting a private post will restrict the quoting post’s visibility to private or direct (if the given visibility is public or unlisted, private will be used instead). An error will be returned when making a quote post with direct visibility and the quote author is not explicitly mentioned. If the status text doesn’t include a link to the quoted post, Mastodon will prepend a <p class="quote-inline">RE: <a href="…">…</a></p> paragraph for backward compatibility (such a paragraph will be hidden by Mastodon’s web interface). */
   readonly quotedStatusId?: string | null;
-  /** Sets who is allowed to quote the status. When omitted, the user’s default setting will be used instead. Ignored if visibility is private or direct, in which case the policy will always be set to nobody.
-   public = Anyone is allowed to quote this status and will have their quote automatically accepted, unless they are blocked.
-   followers = Only followers and the author are allowed to quote this status, and will have their quote automatically accepted.
-   nobody = Only the author is allowed to quote the status.*/
+  /** Sets who is allowed to quote the status. When omitted, the user’s default setting will be used instead. Ignored if visibility is private or direct, in which case the policy will always be set to nobody. */
   readonly quoteApprovalPolicy?: QuoteApprovalPolicy | null;
   /** Mark status and attached media as sensitive? */
   readonly sensitive?: boolean | null;


### PR DESCRIPTION
There are several new props in `AccountSource` including `quote_policy` for the quote feature.

ref. Account - Mastodon documentation - https://docs.joinmastodon.org/entities/Account/