### PR TITLE
fix: Update import in interfaces/ws.ts

### DIFF
--- a/src/interfaces/ws.ts
+++ b/src/interfaces/ws.ts
@@ -1,4 +1,4 @@
-import { type WebSocket } from "isomorphic-ws";
+import { type WebSocket } from "ws";
 
 export interface WebSocketConnector extends AsyncIterable<WebSocket> {
   acquire(): Promise<WebSocket>;


### PR DESCRIPTION
While trying to compile my project with masto for the first time I got greeted by this error.

```
node_modules/masto/dist/esm/interfaces/ws.d.ts:1:15 - error TS2595: 'WebSocket' can only be imported by using a default import.

1 import { type WebSocket } from "isomorphic-ws";
                ~~~~~~~~~

node_modules/masto/dist/esm/interfaces/ws.d.ts:1:32 - error TS2497: This module can only be referenced with ECMAScript imports/exports by turning on the 'allowSyntheticDefaultImports' flag and referencing its default export.
1 import { type WebSocket } from "isomorphic-ws";
                                 ~~~~~~~~~~~~~~~


Found 2 errors in the same file, starting at: node_modules/masto/dist/esm/interfaces/ws.d.ts:1
```

(turning `allowSyntheticDefaultImports` on didn't help btw.)

After debugging the issue longer than I wish to admit, I found the issue to be a wierdly generated `index.d.ts` file of "isomorphic-ws".

Luckily the fix was very simple: I changed the import statement to import `type WebSocket` from the package `ws` instead. Under the hood "isomorphic-ws" was doing exactly that anyways.

All tests ran successful on my machine and my project finally compiles, so that should be it on my side.
