### PR TITLE
fix: Add missing Application entity fields introduced in Mastodon 4.3/4.4

### DIFF
--- a/src/mastodon/entities/v1/application.ts
+++ b/src/mastodon/entities/v1/application.ts
@@ -1,12 +1,16 @@
 /**
  * Represents an application that interfaces with the REST API to access accounts or post statuses.
- * @see https://docs.joinmastodon.org/entities/application/
+ * @see https://docs.joinmastodon.org/entities/Application/
  */
 export interface Application {
   /** The name of your application. */
   name: string;
   /** The website associated with your application. */
   website?: string | null;
+  /** The OAuth scopes requested for this application. Added in 4.3.0. */
+  scopes?: string[] | null;
+  /** Redirect URIs registered for this application. Added in 4.3.0. */
+  redirectUris?: string[] | null;
   /** Used for Push Streaming API. Returned with POST /api/v1/apps. Equivalent to PushSubscription#server_key */
   vapidKey?: string | null;
 }
@@ -16,4 +20,6 @@ export interface Client extends Application {
   clientId?: string | null;
   /** Client secret key, to be used for obtaining OAuth tokens */
   clientSecret?: string | null;
+  /** When the client secret expires. Returns "0" if it doesn't expire. Added in 4.4.0. */
+  clientSecretExpiresAt?: string | null;
 }


### PR DESCRIPTION
## Summary

Fixes #1408

- Add `scopes?: string[] | null` to `Application` (added in Mastodon 4.3.0)
- Add `redirectUris?: string[] | null` to `Application` (added in Mastodon 4.3.0)
- Add `clientSecretExpiresAt?: string | null` to `Client` (added in Mastodon 4.4.0)
- Fix doc link casing (`application` → `Application`)

## Test plan

- [x] Build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)