### PR TITLE
fix: Use multipart/form-data in PUT /api/v1/profile

### DIFF
--- a/src/adapters/action/dispatcher-http-hook-mastodon.ts
+++ b/src/adapters/action/dispatcher-http-hook-mastodon.ts
@@ -43,7 +43,8 @@ function inferEncoding(action: HttpActionType, path: string): Encoding {
     (action === "create" && path === "/api/v1/email") ||
     (action === "create" && path === "/api/v1/featured_tag") ||
     (action === "create" && path === "/api/v1/media") ||
-    (action === "create" && path === "/api/v2/media")
+    (action === "create" && path === "/api/v2/media") ||
+    (action === "update" && path === "/api/v1/profile")
   ) {
     return "multipart-form";
   }


### PR DESCRIPTION
related to #1413

I have not verified if this works since Mastodon 4.6.0 hasn't been officially released yet