### PR TITLE
fix: Revert "chore: use GITHUB_TOKEN instead of PAT in release-please workflow"

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,7 +19,11 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # > By default, Release Please uses the built-in GITHUB_TOKEN secret.
+          # > However, all resources created by release-please (release tag or release pull request) will not trigger future GitHub actions workflows,
+          # > and workflows normally triggered by release.created events will also not run.
+          # https://github.com/googleapis/release-please-action?tab=readme-ov-file#other-actions-on-release-please-prs
+          token: ${{ secrets.GH_PAT }}
           release-type: node
 
       - uses: actions/checkout@v4


### PR DESCRIPTION
Reverts neet/masto.js#1410