### PR TITLE
feat: support `added_to_collection` and `collection_update` notifications

### DIFF
--- a/src/mastodon/entities/v1/grouped-notifications.ts
+++ b/src/mastodon/entities/v1/grouped-notifications.ts
@@ -1,5 +1,6 @@
 import { type Account } from "./account.js";
 import { type AccountWarning } from "./account-warning.js";
+import { type Collection } from "./collection.js";
 import { type RelationshipSeveranceEvent } from "./relationship-severance-event.js";
 import { type Report } from "./report.js";
 import { type Status } from "./status.js";
@@ -70,6 +71,11 @@ type NotificationGroupWithModerationWarning<T> = BaseNotificationGroup<T> & {
   moderationWarning: AccountWarning;
 };
 
+type NotificationGroupWithCollection<T> = BaseNotificationGroup<T> & {
+  /** Collection that was the object of the notification. Attached when type of the notification is added_to_collection or collection_update. */
+  collection: Collection;
+};
+
 /** Someone mentioned you in their status */
 export type MentionNotificationGroup = NotificationGroupWithStatusId<"mention">;
 
@@ -119,6 +125,14 @@ export type SeveredRelationshipsNotificationGroup =
 export type ModerationWarningNotificationGroup =
   NotificationGroupWithModerationWarning<"moderation_warning">;
 
+/** Someone added you to a Collection */
+export type AddedToCollectionNotificationGroup =
+  NotificationGroupWithCollection<"added_to_collection">;
+
+/** A Collection you are featured in was updated */
+export type CollectionUpdateNotificationGroup =
+  NotificationGroupWithCollection<"collection_update">;
+
 export interface NotificationGroupRegistry {
   mention: MentionNotificationGroup;
   status: StatusNotificationGroup;
@@ -134,6 +148,8 @@ export interface NotificationGroupRegistry {
   "admin.report": AdminReportNotificationGroup;
   severed_relationships: SeveredRelationshipsNotificationGroup;
   moderation_warning: ModerationWarningNotificationGroup;
+  added_to_collection: AddedToCollectionNotificationGroup;
+  collection_update: CollectionUpdateNotificationGroup;
 }
 
 /** Group key identifying the grouped notifications. Should be treated as an opaque value. */

--- a/src/mastodon/entities/v1/notification.ts
+++ b/src/mastodon/entities/v1/notification.ts
@@ -1,5 +1,6 @@
 import { type Account } from "./account.js";
 import { type AccountWarning } from "./account-warning.js";
+import { type Collection } from "./collection.js";
 import { type RelationshipSeveranceEvent } from "./relationship-severance-event.js";
 import { type Report } from "./report.js";
 import { type Status } from "./status.js";
@@ -113,6 +114,22 @@ export type ModerationWarningNotification =
     moderationWarning: AccountWarning;
   };
 
+/**
+ * Someone added you to a Collection
+ */
+export type AddedToCollectionNotification =
+  BaseNotificationPlain<"added_to_collection"> & {
+    collection: Collection;
+  };
+
+/**
+ * A Collection you are featured in was updated
+ */
+export type CollectionUpdateNotification =
+  BaseNotificationPlain<"collection_update"> & {
+    collection: Collection;
+  };
+
 export interface NotificationRegistry {
   mention: MentionNotification;
   status: StatusNotification;
@@ -128,6 +145,8 @@ export interface NotificationRegistry {
   "admin.report": AdminReportNotification;
   severed_relationships: SeveredRelationshipsNotification;
   moderation_warning: ModerationWarningNotification;
+  added_to_collection: AddedToCollectionNotification;
+  collection_update: CollectionUpdateNotification;
 }
 
 /**


### PR DESCRIPTION
follows #1425

Mastodon v4.6 also added new two types of notifications: `added_to_collection` and `collection_update`.

ref. Notification - Mastodon documentation - https://docs.joinmastodon.org/entities/Notification/#collection-optional

Grouped notification docs (https://docs.joinmastodon.org/methods/grouped_notifications/) doesn't cover Collection yet but the actual Masotodon server returns Collection notification in grouped notifiation array:

<img width="1525" height="559" alt="Screenshot dev tool network tab showing grouped notification API response JSON" src="https://github.com/user-attachments/assets/e74a10ba-4e4e-4593-9257-faad4e8af9fe" />
