### PR TITLE
fix: Distinguish optional and nullable entity properties

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,6 +10,7 @@ import tseslint from "typescript-eslint";
 
 import allowNullInOptionalParameter from "./eslint/allow-null-in-optional-parameter.js";
 import namingConvention from "./eslint/naming-convention.js";
+import separateOptionalNullableProperty from "./eslint/separate-optional-nullable-property.js";
 
 export default defineConfig(
   eslint.configs.recommended,
@@ -31,6 +32,7 @@ export default defineConfig(
         rules: {
           "allow-null-in-optional-parameter": allowNullInOptionalParameter,
           "naming-convention": namingConvention,
+          "separate-optional-nullable-property": separateOptionalNullableProperty,
         },
       },
     },
@@ -76,6 +78,12 @@ export default defineConfig(
     rules: {
       "masto/naming-convention": ["error"],
       "masto/allow-null-in-optional-parameter": ["error"],
+    },
+  },
+  {
+    files: ["src/mastodon/entities/**/*.ts"],
+    rules: {
+      "masto/separate-optional-nullable-property": ["error"],
     },
   },
   {

--- a/eslint/separate-optional-nullable-property.js
+++ b/eslint/separate-optional-nullable-property.js
@@ -1,0 +1,29 @@
+export default {
+  meta: {
+    type: "problem",
+    schema: [],
+    messages: {
+      default: "Annotate optional and nullable entity properties separately",
+    },
+  },
+
+  create(context) {
+    return {
+      TSPropertySignature(node) {
+        if (
+          node.optional &&
+          node.typeAnnotation.type === "TSTypeAnnotation" &&
+          node.typeAnnotation.typeAnnotation.type === "TSUnionType" &&
+          node.typeAnnotation.typeAnnotation.types.some(
+            (type) => type.type === "TSNullKeyword",
+          )
+        ) {
+          context.report({
+            node,
+            messageId: "default",
+          });
+        }
+      },
+    };
+  },
+};

--- a/eslint/separate-optional-nullable-property.spec.js
+++ b/eslint/separate-optional-nullable-property.spec.js
@@ -1,0 +1,30 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+
+import rule from "./separate-optional-nullable-property.js";
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("separate-optional-nullable-property", rule, {
+  valid: [
+    `
+    interface Account {
+      discoverable: boolean | null;
+      suspended?: boolean;
+    }
+    `,
+  ],
+  invalid: [
+    {
+      code: `
+      interface Account {
+        discoverable?: boolean | null;
+      }
+      `,
+      errors: [
+        {
+          message: "Annotate optional and nullable entity properties separately",
+        },
+      ],
+    },
+  ],
+});

--- a/src/mastodon/entities/entity-property-types.spec.ts
+++ b/src/mastodon/entities/entity-property-types.spec.ts
@@ -1,0 +1,60 @@
+import { expectTypeOf, test } from "vitest";
+
+import { type Account, type AccountSource } from "./v1/account.js";
+import { type Application } from "./v1/application.js";
+import { type DomainBlock } from "./v1/domain-block.js";
+import {
+  type MediaAttachment,
+  type MediaAttachmentMeta,
+  type MediaAttachmentMetaFocus,
+} from "./v1/media-attachment.js";
+import { type NotificationRequest } from "./v1/notification-request.js";
+import { type Poll } from "./v1/poll.js";
+import { type Quote } from "./v1/quote.js";
+import { type ShallowQuote } from "./v1/shallow-quote.js";
+import { type Status } from "./v1/status.js";
+import { type InstanceRegistrations } from "./v2/instance.js";
+
+type IsOptional<T, K extends keyof T> = Pick<T, K> extends Required<Pick<T, K>>
+  ? false
+  : true;
+
+test("keeps nullable and optional entity properties distinct", () => {
+  expectTypeOf<Account["discoverable"]>().toEqualTypeOf<boolean | null>();
+  expectTypeOf<Account["noindex"]>().toEqualTypeOf<boolean | undefined>();
+  expectTypeOf<Account["moved"]>().toEqualTypeOf<Account | undefined>();
+  expectTypeOf<IsOptional<Account, "discoverable">>().toEqualTypeOf<false>();
+  expectTypeOf<IsOptional<Account, "noindex">>().toEqualTypeOf<true>();
+
+  expectTypeOf<AccountSource["privacy"]>().toEqualTypeOf<
+    "public" | "unlisted" | "private" | "direct"
+  >();
+  expectTypeOf<Application["website"]>().toEqualTypeOf<string | null>();
+  expectTypeOf<Application["scopes"]>().toEqualTypeOf<string[]>();
+  expectTypeOf<DomainBlock["comment"]>().toEqualTypeOf<string | undefined>();
+
+  expectTypeOf<Status["quote"]>().toEqualTypeOf<
+    Quote | ShallowQuote | null
+  >();
+  expectTypeOf<Status["favourited"]>().toEqualTypeOf<boolean | undefined>();
+  expectTypeOf<IsOptional<Status, "quote">>().toEqualTypeOf<false>();
+  expectTypeOf<IsOptional<Status, "favourited">>().toEqualTypeOf<true>();
+
+  expectTypeOf<Poll["expiresAt"]>().toEqualTypeOf<string | null>();
+  expectTypeOf<Poll["ownVotes"]>().toEqualTypeOf<number[] | undefined>();
+  expectTypeOf<NotificationRequest["lastStatus"]>().toEqualTypeOf<
+    Status | undefined
+  >();
+
+  expectTypeOf<MediaAttachment["description"]>().toEqualTypeOf<string | null>();
+  expectTypeOf<MediaAttachmentMeta["focus"]>().toEqualTypeOf<
+    MediaAttachmentMetaFocus | undefined
+  >();
+  expectTypeOf<
+    IsOptional<MediaAttachmentMeta, "focus">
+  >().toEqualTypeOf<true>();
+
+  expectTypeOf<InstanceRegistrations["message"]>().toEqualTypeOf<
+    string | null
+  >();
+});

--- a/src/mastodon/entities/v1/account-warning.ts
+++ b/src/mastodon/entities/v1/account-warning.ts
@@ -28,7 +28,7 @@ export interface AccountWarning {
   /** Account against which a moderation decision has been taken. */
   targetAccount: Account;
   /** Appeal submitted by the target account, if any. */
-  appeal?: Appeal | null;
+  appeal: Appeal | null;
   /** When the event took place. */
   createdAt: string;
 }

--- a/src/mastodon/entities/v1/account.ts
+++ b/src/mastodon/entities/v1/account.ts
@@ -17,17 +17,17 @@ export interface AccountSource {
   /** Metadata about the account. */
   fields: AccountField[];
   /** The default post privacy to be used for new statuses. */
-  privacy?: StatusVisibility | null;
+  privacy: StatusVisibility;
   /** Whether new statuses should be marked sensitive by default. */
-  sensitive?: boolean | null;
+  sensitive: boolean;
   /** The default posting language for new statuses. */
   language: string | null;
   /** The number of pending follow requests. */
-  followRequestsCount?: number | null;
+  followRequestsCount: number;
   /** Whether the user hides the contents of their follows and followers collections. */
-  hideCollections?: boolean | null;
+  hideCollections: boolean | null;
   /**  Whether the account has opted into discovery features such as the profile directory. */
-  discoverable?: boolean | null;
+  discoverable: boolean | null;
   /** Whether public posts should be searchable to anyone. */
   indexable: boolean;
   /** The default quote policy to be used for new statuses. */
@@ -45,7 +45,7 @@ export interface AccountField {
   /** The value associated with the `name` key. */
   value: string;
   /** Timestamp of when the server verified a URL value for a rel="me” link. */
-  verifiedAt?: string | null;
+  verifiedAt: string | null;
 }
 
 /**
@@ -84,15 +84,15 @@ export interface Account {
   /** Indicates that the account represents a Group actor. */
   group: boolean;
   /** Whether the account has opted into discovery features such as the profile directory. */
-  discoverable?: boolean | null;
+  discoverable: boolean | null;
   /** Whether the local user has opted out of being indexed by search engines. */
-  noindex?: boolean | null;
+  noindex?: boolean;
   /** Indicates that the profile is currently inactive and that its user has moved to a new account. */
-  moved?: Account | null;
+  moved?: Account;
   /** An extra entity returned when an account is suspended. **/
-  suspended?: boolean | null;
+  suspended?: boolean;
   /** An extra attribute returned only when an account is silenced. If true, indicates that the account should be hidden behind a warning screen. */
-  limited?: boolean | null;
+  limited?: boolean;
   /** When the account was created. */
   createdAt: string;
   /** Time of the last status posted */
@@ -106,7 +106,7 @@ export interface Account {
   /** Roles that have been granted to this account. */
   roles: Pick<Role, "id" | "name" | "color">[]; // TODO: Create an entity when documentation is updated
   /** https://github.com/mastodon/mastodon/pull/23591 */
-  memorial?: boolean | null;
+  memorial?: boolean;
   /** Summary of the account’s policy with regards to being featured in a Collection and how it applies to the user making the request. */
   featureApproval: FeatureApproval;
 }

--- a/src/mastodon/entities/v1/admin/account.ts
+++ b/src/mastodon/entities/v1/admin/account.ts
@@ -12,19 +12,19 @@ export interface Account {
   /** The username of the account. */
   username: string;
   /** The domain of the account. */
-  domain?: string | null;
+  domain: string | null;
   /** When the account was first discovered. */
   createdAt: string;
   /** The email address associated with the account. */
   email: string;
   /** The IP address last used to login to this account. */
-  ip?: string | null;
+  ip: string | null;
   /** All known IP addresses associated with this account. */
   ips: Ip[];
   /** The locale of the account. */
   locale: string;
   /** The reason given when requesting an invite (for instances that require manual approval of registrations) */
-  inviteRequest?: string | null;
+  inviteRequest: string | null;
   /** The current role of the account. */
   role: Role;
   /** Whether the account has confirmed their email address. */
@@ -42,7 +42,7 @@ export interface Account {
   /** User-level information about the account. */
   account: PublicAccount;
   /** The ID of the application that created this account. */
-  createdByApplicationId?: string | null;
+  createdByApplicationId?: string;
   /** The ID of the account that invited this user */
-  invitedByAccountId?: string | null;
+  invitedByAccountId?: string;
 }

--- a/src/mastodon/entities/v1/admin/dimension.ts
+++ b/src/mastodon/entities/v1/admin/dimension.ts
@@ -6,9 +6,9 @@ export interface DimensionData {
   /** The value for this data item. */
   value: string;
   /** The units associated with this data item’s value, if applicable. */
-  unit?: string | null;
+  unit?: string;
   /** A human-readable formatted value for this data item. */
-  humanValue?: string | null;
+  humanValue?: string;
 }
 
 export interface DimensionKeyRegistry {

--- a/src/mastodon/entities/v1/admin/domain-block.ts
+++ b/src/mastodon/entities/v1/admin/domain-block.ts
@@ -20,9 +20,9 @@ export interface DomainBlock {
   /** The reject report of the domain. */
   rejectReposts: boolean;
   /** The private comment of the domain. */
-  privateComment?: string | null;
+  privateComment: string | null;
   /** The public comment of the domain. */
-  publicComment?: string | null;
+  publicComment: string | null;
   /** The obfuscate of the domain block. */
   obfuscate: boolean;
   /** SHA256 of the domain. https://github.com/mastodon/mastodon/pull/29092 */

--- a/src/mastodon/entities/v1/admin/measure.ts
+++ b/src/mastodon/entities/v1/admin/measure.ts
@@ -33,7 +33,7 @@ export interface Measure {
   /** The unique keystring for the requested measure. */
   key: MeasureKey;
   /** The units associated with this data item’s value, if applicable. */
-  unit?: string | null;
+  unit: string | null;
   /** The numeric total associated with the requested measure. */
   total: string;
   /** A human-readable formatted value for this data item. */

--- a/src/mastodon/entities/v1/admin/report.ts
+++ b/src/mastodon/entities/v1/admin/report.ts
@@ -13,7 +13,7 @@ export interface Report {
   /** The action taken to resolve this report. */
   actionTaken: boolean;
   /** When an action was taken, if this report is currently resolved. */
-  actionTakenAt?: string | null;
+  actionTakenAt: string | null;
   /** The category under which the report is classified */
   category: ReportCategory;
   /** An optional reason for reporting. */
@@ -29,7 +29,7 @@ export interface Report {
   /** The account being reported. */
   targetAccount: Account;
   /** The account of the moderator assigned to this report. */
-  assignedAccount?: Account | null;
+  assignedAccount: Account | null;
   /** The action taken by the moderator who handled the report. */
   actionTakenByAccount: Account;
   /** Statuses attached to the report, for context. */

--- a/src/mastodon/entities/v1/annual-report.ts
+++ b/src/mastodon/entities/v1/annual-report.ts
@@ -43,7 +43,7 @@ export interface AnnualReport {
   /** The schema version of the report, defines how to interpret data. */
   schemaVersion: number;
   /** An optional link to a shareable version of the report. */
-  shareUrl?: string | null;
+  shareUrl: string | null;
   /** The account ID the report is about. */
   accountId: string;
 }

--- a/src/mastodon/entities/v1/application.ts
+++ b/src/mastodon/entities/v1/application.ts
@@ -6,20 +6,20 @@ export interface Application {
   /** The name of your application. */
   name: string;
   /** The website associated with your application. */
-  website?: string | null;
+  website: string | null;
   /** The OAuth scopes requested for this application. Added in 4.3.0. */
-  scopes?: string[] | null;
+  scopes: string[];
   /** Redirect URIs registered for this application. Added in 4.3.0. */
-  redirectUris?: string[] | null;
+  redirectUris: string[];
   /** Used for Push Streaming API. Returned with POST /api/v1/apps. Equivalent to PushSubscription#server_key */
-  vapidKey?: string | null;
+  vapidKey: string;
 }
 
 export interface Client extends Application {
   /** Client ID key, to be used for obtaining OAuth tokens */
-  clientId?: string | null;
+  clientId: string;
   /** Client secret key, to be used for obtaining OAuth tokens */
-  clientSecret?: string | null;
+  clientSecret: string;
   /** When the client secret expires. Returns "0" if it doesn't expire. Added in 4.4.0. */
-  clientSecretExpiresAt?: string | null;
+  clientSecretExpiresAt: string;
 }

--- a/src/mastodon/entities/v1/conversation.ts
+++ b/src/mastodon/entities/v1/conversation.ts
@@ -14,5 +14,5 @@ export interface Conversation {
   unread: boolean;
 
   /** The last status in the conversation, to be used for optional display. */
-  lastStatus?: Status | null;
+  lastStatus: Status | null;
 }

--- a/src/mastodon/entities/v1/custom-emoji.ts
+++ b/src/mastodon/entities/v1/custom-emoji.ts
@@ -13,5 +13,5 @@ export interface CustomEmoji {
   visibleInPicker: boolean;
 
   /** Used for sorting custom emoji in the picker. */
-  category?: string | null;
+  category: string | null;
 }

--- a/src/mastodon/entities/v1/domain-block.ts
+++ b/src/mastodon/entities/v1/domain-block.ts
@@ -16,5 +16,5 @@ export interface DomainBlock {
   /** The level to which the domain is blocked. */
   severity: DomainBlockSeverity;
   /** An optional reason for the domain block. */
-  comment?: string | null;
+  comment?: string;
 }

--- a/src/mastodon/entities/v1/extended-description.ts
+++ b/src/mastodon/entities/v1/extended-description.ts
@@ -5,5 +5,5 @@ export interface ExtendedDescription {
   /** The rendered HTML content of the extended description. */
   content: string;
   /** A timestamp of when the extended description was last updated. */
-  updatedAt?: string | null;
+  updatedAt: string;
 }

--- a/src/mastodon/entities/v1/featured-tags.ts
+++ b/src/mastodon/entities/v1/featured-tags.ts
@@ -12,5 +12,5 @@ export interface FeaturedTag {
   /** The number of authored statuses containing this hashtag */
   statusesCount: number;
   /** The timestamp of the last authored status containing this hashtag. */
-  lastStatusAt?: string | null;
+  lastStatusAt: string | null;
 }

--- a/src/mastodon/entities/v1/filter.ts
+++ b/src/mastodon/entities/v1/filter.ts
@@ -20,7 +20,7 @@ export interface Filter {
   /** The contexts in which the filter should be applied. */
   context: FilterContext[];
   /** When the filter should no longer be applied */
-  expiresAt?: string | null;
+  expiresAt: string | null;
   /** Should matching entities in home and notifications be dropped by the server? */
   irreversible: boolean;
   /** Should the filter consider word boundaries? */

--- a/src/mastodon/entities/v1/instance.ts
+++ b/src/mastodon/entities/v1/instance.ts
@@ -70,11 +70,11 @@ export interface Instance {
   configuration: InstanceConfiguration;
 
   /** Banner image for the website. */
-  thumbnail?: string | null;
+  thumbnail: string | null;
   /** A user that can be contacted, as an alternative to `email`. */
-  contactAccount?: Account | null;
+  contactAccount: Account | null;
 
-  rules?: Rule[] | null;
+  rules: Rule[];
 }
 
 export interface InstanceURLs {

--- a/src/mastodon/entities/v1/media-attachment.ts
+++ b/src/mastodon/entities/v1/media-attachment.ts
@@ -36,10 +36,10 @@ export interface MediaAttachmentMetaColors {
 }
 
 export interface MediaAttachmentMeta {
-  small?: MediaAttachmentMetaImage | MediaAttachmentMetaVideo | null;
-  original?: MediaAttachmentMetaImage | MediaAttachmentMetaVideo | null;
-  focus?: MediaAttachmentMetaFocus | null;
-  colors?: MediaAttachmentMetaColors | null;
+  small?: MediaAttachmentMetaImage | MediaAttachmentMetaVideo;
+  original?: MediaAttachmentMetaImage | MediaAttachmentMetaVideo;
+  focus?: MediaAttachmentMetaFocus;
+  colors?: MediaAttachmentMetaColors;
 }
 
 /**
@@ -52,25 +52,25 @@ export interface MediaAttachment {
   /** The type of the MediaAttachment. */
   type: MediaAttachmentType;
   /** The location of the original full-size MediaAttachment. */
-  url?: string | null;
+  url: string | null;
   /** The location of a scaled-down preview of the MediaAttachment. */
   previewUrl: string;
   /** The location of the full-size original MediaAttachment on the remote website. */
-  remoteUrl?: string | null;
+  remoteUrl: string | null;
   /** Remote version of previewUrl */
-  previewRemoteUrl?: string | null;
+  previewRemoteUrl: string | null;
   /** A shorter URL for the MediaAttachment. */
-  textUrl?: string | null;
+  textUrl: string | null;
   /** Metadata returned by Paperclip. */
-  meta?: MediaAttachmentMeta | null;
+  meta: MediaAttachmentMeta | null;
   /**
    * Alternate text that describes what is in the media MediaAttachment,
    * to be used for the visually impaired or when media MediaAttachments do not load.
    */
-  description?: string | null;
+  description: string | null;
   /**
    * A hash computed by the BlurHash algorithm,
    * for generating colorful preview thumbnails when media has not been downloaded yet.
    */
-  blurhash?: string | null;
+  blurhash: string | null;
 }

--- a/src/mastodon/entities/v1/notification-request.ts
+++ b/src/mastodon/entities/v1/notification-request.ts
@@ -13,5 +13,5 @@ export interface NotificationRequest {
   /** How many of this account’s notifications were filtered. */
   notificationsCount: number;
   /** Most recent status associated with a filtered notification from that account. */
-  lastStatus?: Status | null;
+  lastStatus?: Status;
 }

--- a/src/mastodon/entities/v1/notification.ts
+++ b/src/mastodon/entities/v1/notification.ts
@@ -20,21 +20,21 @@ interface BaseNotification<T> {
 
 type BaseNotificationPlain<T> = BaseNotification<T> & {
   /** Status that was the object of the notification, e.g. in mentions, reblogs, favourites, or polls. */
-  status?: undefined | null;
+  status?: undefined;
   /** Report that was the object of the notification. Attached when type of the notification is admin.report. */
-  report?: undefined | null;
+  report?: undefined;
 };
 
 type BaseNotificationWithStatus<T> = BaseNotification<T> & {
   /** Status that was the object of the notification, e.g. in mentions, reblogs, favourites, or polls. */
   status: Status;
   /** Report that was the object of the notification. Attached when type of the notification is admin.report. */
-  report?: undefined | null;
+  report?: undefined;
 };
 
 type BaseNotificationWithReport<T> = BaseNotification<T> & {
   /** Status that was the object of the notification, e.g. in mentions, reblogs, favourites, or polls. */
-  status?: undefined | null;
+  status?: undefined;
   /** Report that was the object of the notification. Attached when type of the notification is admin.report. */
   report: Report;
 };

--- a/src/mastodon/entities/v1/poll.ts
+++ b/src/mastodon/entities/v1/poll.ts
@@ -4,7 +4,7 @@ export interface PollOption {
   /** The text value of the poll option. String. */
   title: string;
   /** The number of received votes for this option. Number, or null if results are not published yet. */
-  votesCount?: number;
+  votesCount: number;
   /** Custom emoji to be used for rendering poll options. */
   emojis: CustomEmoji[];
 }
@@ -17,7 +17,7 @@ export interface Poll {
   /** The ID of the poll in the database. */
   id: string;
   /** When the poll ends. */
-  expiresAt?: string | null;
+  expiresAt: string | null;
   /** Is the poll currently expired? */
   expired: boolean;
   /** Does the poll allow multiple-choice answers? */
@@ -25,14 +25,14 @@ export interface Poll {
   /** How many votes have been received. */
   votesCount: number;
   /** How many unique accounts have voted on a multiple-choice poll. */
-  votersCount?: number | null;
+  votersCount: number | null;
   /** When called with a user token, has the authorized user voted? */
   voted?: boolean;
   /**
    * When called with a user token, which options has the authorized user chosen?
    * Contains an array of index values for options.
    */
-  ownVotes?: number[] | null;
+  ownVotes?: number[];
   /** Possible answers for the poll. */
   options: PollOption[];
 }

--- a/src/mastodon/entities/v1/preview-card.ts
+++ b/src/mastodon/entities/v1/preview-card.ts
@@ -44,30 +44,30 @@ export interface PreviewCard {
    * The author of the original resource.
    * @deprecated Use `authors` instead
    */
-  authorName?: string | null;
+  authorName: string;
   /**
    * A link to the author of the original resource.
    * @deprecated Use `authors` instead
    */
-  authorUrl?: string | null;
+  authorUrl: string;
   /** The provider of the original resource. */
-  providerName?: string | null;
+  providerName: string;
   /** A link to the provider of the original resource. */
-  providerUrl?: string | null;
+  providerUrl: string;
   /** HTML to be used for generating the preview card. */
-  html?: string | null;
+  html: string;
   /** Width of preview, in pixels. */
-  width?: number | null;
+  width: number;
   /** Height of preview, in pixels. */
-  height?: number | null;
+  height: number;
   /** Preview thumbnail. */
-  image?: string | null;
+  image: string | null;
   /** Used for photo embeds, instead of custom `html`. */
   embedUrl: string;
   /** @see https://github.com/mastodon/mastodon/pull/27503 */
-  language?: string;
+  language: string | null;
   /** True if the linked article claims to be written by the current user without the user having the article’s domain in their attribution_domains). This is used to prompt them to review and add the domain. */
-  missingAttribution?: boolean | null;
+  missingAttribution: boolean | null;
 }
 
 export interface TrendLink extends PreviewCard {

--- a/src/mastodon/entities/v1/quote.ts
+++ b/src/mastodon/entities/v1/quote.ts
@@ -22,5 +22,5 @@ export interface Quote {
   /* The state of the quote */
   state: QuoteState;
   /* The status being quoted, if the quote has been accepted. This will be null, unless the state attribute is accepted. */
-  quotedStatus?: Status | null;
+  quotedStatus: Status | null;
 }

--- a/src/mastodon/entities/v1/reaction.ts
+++ b/src/mastodon/entities/v1/reaction.ts
@@ -1,7 +1,7 @@
 export interface Reaction {
   name: string;
   count: number;
-  me: boolean;
-  url: string;
-  staticUrl: string;
+  me?: boolean;
+  url?: string;
+  staticUrl?: string;
 }

--- a/src/mastodon/entities/v1/relationship.ts
+++ b/src/mastodon/entities/v1/relationship.ts
@@ -30,7 +30,7 @@ export interface Relationship {
   /** Are you featuring this user on your profile? */
   endorsed: boolean;
   /** Personal note for this account */
-  note?: string | null;
+  note: string;
   /** Whether the represented user has requested to follow you */
   requestedBy: boolean;
 }

--- a/src/mastodon/entities/v1/report.ts
+++ b/src/mastodon/entities/v1/report.ts
@@ -19,7 +19,7 @@ export interface Report {
   /** Whether an action was taken yet. */
   actionTaken: boolean;
   /** When an action was taken against the report. */
-  actionTakenAt?: string | null;
+  actionTakenAt: string | null;
   /**
    * The generic reason for the report.
    *
@@ -37,9 +37,9 @@ export interface Report {
   /** When the report was created */
   createdAt: string;
   /** IDs of statuses that have been attached to this report for additional context. */
-  statusIds?: string[] | null;
+  statusIds: string[] | null;
   /** IDs of the rules that have been cited as a violation by this report. */
-  ruleIds?: string[] | null;
+  ruleIds: string[] | null;
   /** The account that was reported. */
   targetAccount: Account;
 }

--- a/src/mastodon/entities/v1/scheduled-status.ts
+++ b/src/mastodon/entities/v1/scheduled-status.ts
@@ -8,7 +8,7 @@ export interface StatusParams extends Pick<
   /** Content of the status */
   text: string;
   /** IDs of media attachments */
-  mediaIds?: string[] | null;
+  mediaIds: string[] | null;
   /** ID of the application */
   applicationId: string;
 }

--- a/src/mastodon/entities/v1/shallow-quote.ts
+++ b/src/mastodon/entities/v1/shallow-quote.ts
@@ -8,5 +8,5 @@ export interface ShallowQuote {
   /* The state of the quote. */
   state: QuoteState;
   /* The identifier of the status being quoted, if the quote has been accepted. This will be null, unless the state attribute is accepted. */
-  quotedStatusId?: string | null;
+  quotedStatusId: string | null;
 }

--- a/src/mastodon/entities/v1/status.ts
+++ b/src/mastodon/entities/v1/status.ts
@@ -53,7 +53,7 @@ export interface Status {
   /** The account that authored this status. */
   account: Account;
   /** HTML-encoded status content. */
-  content: string;
+  content?: string;
   /** Visibility of this status. */
   visibility: StatusVisibility;
   /** Is this status marked as sensitive content? */
@@ -63,7 +63,7 @@ export interface Status {
   /** Media that is attached to this status. */
   mediaAttachments: MediaAttachment[];
   /** The application used to post this status. */
-  application: Application;
+  application?: Application;
 
   /** Mentions of users within the status content. */
   mentions: StatusMention[];
@@ -81,7 +81,7 @@ export interface Status {
   /** How many replies this status has received. */
   repliesCount: number;
   /** Information about the status being quoted, if any */
-  quote?: Quote | ShallowQuote | null;
+  quote: Quote | ShallowQuote | null;
   /** How many replies this status has received. */
   quotesCount: number;
   /**
@@ -91,34 +91,34 @@ export interface Status {
   quoteApproval: QuoteApproval;
 
   /** A link to the status's HTML representation. */
-  url?: string | null;
+  url: string | null;
   /** ID of the status being replied. */
-  inReplyToId?: string | null;
+  inReplyToId: string | null;
   /** ID of the account being replied to. */
-  inReplyToAccountId?: string | null;
+  inReplyToAccountId: string | null;
   /** The status being reblogged. */
-  reblog?: Status | null;
+  reblog: Status | null;
   /** The poll attached to the status. */
-  poll?: Poll | null;
+  poll: Poll | null;
   /** Preview card for links included within status content. */
-  card?: PreviewCard | null;
+  card: PreviewCard | null;
   /** Primary language of this status. */
-  language?: string | null;
+  language: string | null;
   /**
    * Plain-text source of a status. Returned instead of `content` when status is deleted,
    * so the user may redraft from the source text without the client having
    * to reverse-engineer the original text from the HTML content.
    */
-  text?: string | null;
+  text?: string;
 
   /** Have you favourited this status? */
-  favourited?: boolean | null;
+  favourited?: boolean;
   /** Have you boosted this status? */
-  reblogged?: boolean | null;
+  reblogged?: boolean;
   /** Have you muted notifications for this status's conversation? */
-  muted?: boolean | null;
+  muted?: boolean;
   /** Have you bookmarked this status? */
-  bookmarked?: boolean | null;
+  bookmarked?: boolean;
   /** Have you pinned this status? Only appears if the status is pin-able. */
-  pinned?: boolean | null;
+  pinned?: boolean;
 }

--- a/src/mastodon/entities/v1/tag.ts
+++ b/src/mastodon/entities/v1/tag.ts
@@ -22,9 +22,9 @@ export interface Tag {
   /** A link to the hashtag on the instance. */
   url: string;
   /** Usage statistics for given days. */
-  history?: TagHistory[] | null;
+  history: TagHistory[];
   /** Whether the current token’s authorized user is following this tag. */
-  following?: boolean | null;
+  following?: boolean;
   /** Whether the current token’s authorized user is featuring this tag on their profile. */
-  featuring?: boolean | null;
+  featuring?: boolean;
 }

--- a/src/mastodon/entities/v2/filter.ts
+++ b/src/mastodon/entities/v2/filter.ts
@@ -31,7 +31,7 @@ export interface Filter {
   /** The contexts in which the filter should be applied. */
   context: FilterContext[];
   /** When the filter should no longer be applied */
-  expiresAt?: string | null;
+  expiresAt: string | null;
   /**
    * The action to be taken when a status matches this filter.
    *
@@ -43,7 +43,7 @@ export interface Filter {
    */
   filterAction: FilterAction;
   /** The keywords grouped under this filter. */
-  keywords: FilterKeyword[];
+  keywords?: FilterKeyword[];
   /** The statuses grouped under this filter. */
-  statuses: FilterStatus[];
+  statuses?: FilterStatus[];
 }

--- a/src/mastodon/entities/v2/instance.ts
+++ b/src/mastodon/entities/v2/instance.ts
@@ -12,18 +12,18 @@ export interface InstanceUsage {
 
 export interface InstanceThumbnailVersions {
   /** The URL for the thumbnail image at 1x resolution. */
-  "@1x": string;
+  "@1x"?: string;
   /** The URL for the thumbnail image at 2x resolution. */
-  "@2x": string;
+  "@2x"?: string;
 }
 
 export interface InstanceThumbnail {
   /** The URL for the thumbnail image. */
   url: string;
   /** A hash computed by [the BlurHash algorithm](https://github.com/woltapp/blurhash), for generating colorful preview thumbnails when media has not been downloaded yet. */
-  blurhash: string;
+  blurhash?: string;
   /** Links to scaled resolution images, for high DPI screens. */
-  versions: InstanceThumbnailVersions;
+  versions?: InstanceThumbnailVersions;
   /** The thumbnail’s alt text (a description of the image to help people with visual impairments understand its content). */
   description: string;
 }
@@ -32,7 +32,7 @@ export interface InstanceUrls {
   /** The WebSockets URL for connecting to the streaming API. */
   streaming: string;
   /** Instance status URL */
-  status?: string;
+  status: string | null;
 }
 
 export interface InstanceAccountsConfiguration {
@@ -123,11 +123,11 @@ export interface InstanceRegistrations {
   /** Whether registrations require moderator approval. */
   approvalRequired: boolean;
   /** A custom message to be shown when registrations are closed. */
-  message?: string | null;
+  message: string | null;
   /** A minimum age required to register, if configured. */
-  minAge?: number | null;
+  minAge: number | null;
   /** Whether registrations require the user to provide a reason for joining. Only applicable when `registrations[approval_required]` is true. */
-  reasonRequired?: boolean | null;
+  reasonRequired: boolean | null;
 }
 
 export interface InstanceContact {
@@ -183,5 +183,5 @@ export interface Instance {
   /** An itemized list of rules for this website. */
   rules: Rule[];
   /** The current Wrapstodon (Annual report campaign identifier (year), if any. */
-  wrapstodon?: string | null;
+  wrapstodon: string | null;
 }

--- a/src/mastodon/rest/v1/accounts.ts
+++ b/src/mastodon/rest/v1/accounts.ts
@@ -66,7 +66,7 @@ export interface UpdateCredentialsParams {
    * Profile metadata `name` and `value`.
    * (By default, max 4 fields and 255 characters per property/value)
    */
-  readonly fieldsAttributes?: AccountField[] | null;
+  readonly fieldsAttributes?: Pick<AccountField, "name" | "value">[] | null;
 }
 
 export interface MuteAccountParams {

--- a/src/mastodon/rest/v1/profile.ts
+++ b/src/mastodon/rest/v1/profile.ts
@@ -38,7 +38,7 @@ export interface UpdateProfileParams {
   /** Domains of websites allowed to credit the account. */
   readonly attributionDomains?: string[] | null;
   /** Profile metadata `name` and `value`. */
-  readonly fieldsAttributes?: AccountField[] | null;
+  readonly fieldsAttributes?: Pick<AccountField, "name" | "value">[] | null;
 }
 
 export interface ProfileAvatarResource {

--- a/tests/rest/v2/filters.spec.ts
+++ b/tests/rest/v2/filters.spec.ts
@@ -97,7 +97,7 @@ describe("filters", () => {
 
     try {
       filter = await session.rest.v2.filters.$select(filter.id).update({
-        keywordsAttributes: [{ id: filter.keywords[0].id, _destroy: true }],
+        keywordsAttributes: [{ id: filter.keywords?.[0].id, _destroy: true }],
       });
       expect(filter.keywords).toHaveLength(1);
     } finally {

--- a/tests/streaming/timelines.spec.ts
+++ b/tests/streaming/timelines.spec.ts
@@ -12,7 +12,7 @@ describe("websocket", () => {
     const eventsPromise = subscription
       .values()
       .filter((e): e is mastodon.streaming.UpdateEvent => e.event === "update")
-      .filter((e) => e.payload.content.includes(random))
+      .filter((e) => e.payload.content?.includes(random))
       .take(1)
       .toArray();
 
@@ -36,7 +36,7 @@ describe("websocket", () => {
     const eventsPromise = subscription
       .values()
       .filter((e): e is mastodon.streaming.UpdateEvent => e.event === "update")
-      .filter((e) => e.payload.content.includes(random))
+      .filter((e) => e.payload.content?.includes(random))
       .take(1)
       .toArray();
 
@@ -65,7 +65,7 @@ describe("websocket", () => {
     const eventsPromise = subscription
       .values()
       .filter((e): e is mastodon.streaming.UpdateEvent => e.event === "update")
-      .filter((e) => e.payload.content.includes(random))
+      .filter((e) => e.payload.content?.includes(random))
       .take(1)
       .toArray();
 
@@ -90,7 +90,7 @@ describe("websocket", () => {
     const eventsPromise = subscription
       .values()
       .filter((e): e is mastodon.streaming.UpdateEvent => e.event === "update")
-      .filter((e) => e.payload.content.includes(random))
+      .filter((e) => e.payload.content?.includes(random))
       .take(1)
       .toArray();
 
@@ -120,7 +120,7 @@ describe("websocket", () => {
     const eventsPromise = subscription
       .values()
       .filter((e): e is mastodon.streaming.UpdateEvent => e.event === "update")
-      .filter((e) => e.payload.content.includes(hashtag))
+      .filter((e) => e.payload.content?.includes(hashtag))
       .take(1)
       .toArray();
 
@@ -146,7 +146,7 @@ describe("websocket", () => {
     const eventsPromise = subscription
       .values()
       .filter((e): e is mastodon.streaming.UpdateEvent => e.event === "update")
-      .filter((e) => e.payload.content.includes(hashtag))
+      .filter((e) => e.payload.content?.includes(hashtag))
       .take(1)
       .toArray();
 


### PR DESCRIPTION
Fixes #1384. Nullable response properties are now required and explicitly include null, while conditionally serialized properties remain optional. Adds type and lint coverage to keep the forms separate.